### PR TITLE
ngpu/vk: only emit non-semantic shader debug info if supported

### DIFF
--- a/libngpu/src/vulkan/glslang_utils.c
+++ b/libngpu/src/vulkan/glslang_utils.c
@@ -51,7 +51,7 @@ int ngpu_glslang_init(void)
     return ret;
 }
 
-int ngpu_glslang_compile(enum ngpu_program_stage stage, const char *src, int debug, void **datap, size_t *sizep)
+int ngpu_glslang_compile(enum ngpu_program_stage stage, const char *src, int debug, int emit_nonsemantic_info, void **datap, size_t *sizep)
 {
     static const glslang_stage_t stages[] = {
         [NGPU_PROGRAM_STAGE_VERT] = GLSLANG_STAGE_VERTEX,
@@ -138,8 +138,8 @@ int ngpu_glslang_compile(enum ngpu_program_stage stage, const char *src, int deb
         .optimize_size = false,
         .disassemble = false,
         .validate = true,
-        .emit_nonsemantic_shader_debug_info = dbg,
-        .emit_nonsemantic_shader_debug_source = dbg,
+        .emit_nonsemantic_shader_debug_info = dbg && emit_nonsemantic_info,
+        .emit_nonsemantic_shader_debug_source = dbg && emit_nonsemantic_info,
     };
     glslang_program_SPIRV_generate_with_options(program, glslc_input.stage, &options);
 #else

--- a/libngpu/src/vulkan/glslang_utils.h
+++ b/libngpu/src/vulkan/glslang_utils.h
@@ -30,7 +30,7 @@
 #include "ngpu/ngpu.h"
 
 int ngpu_glslang_init(void);
-int ngpu_glslang_compile(enum ngpu_program_stage stage, const char *src, int debug, void **datap, size_t *sizep);
+int ngpu_glslang_compile(enum ngpu_program_stage stage, const char *src, int debug, int emit_nonsemantic_info, void **datap, size_t *sizep);
 void ngpu_glslang_uninit(void);
 
 #endif

--- a/libngpu/src/vulkan/program_vk.c
+++ b/libngpu/src/vulkan/program_vk.c
@@ -32,6 +32,10 @@
 #include "utils/string.h"
 #include "utils/utils.h"
 
+#ifndef VK_KHR_SHADER_RELAXED_EXTENDED_INSTRUCTUON_EXTENSION_NAME
+#define VK_KHR_SHADER_RELAXED_EXTENDED_INSTRUCTION_EXTENSION_NAME "VK_KHR_shader_relaxed_extended_instruction"
+#endif
+
 struct ngpu_program *ngpu_program_vk_create(struct ngpu_ctx *gpu_ctx)
 {
     struct ngpu_program_vk *s = ngpu_calloc(1, sizeof(*s));
@@ -48,6 +52,9 @@ int ngpu_program_vk_init(struct ngpu_program *s, const struct ngpu_program_param
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
     struct ngpu_program_vk *s_priv = (struct ngpu_program_vk *)s;
 
+    const int emit_nonsemantic_info = ngpu_vkcontext_has_extension(vk, VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, 1) &&
+                                      ngpu_vkcontext_has_extension(vk, VK_KHR_SHADER_RELAXED_EXTENDED_INSTRUCTION_EXTENSION_NAME, 1);
+
     const struct {
         enum ngpu_program_stage stage;
         const char *src;
@@ -63,7 +70,7 @@ int ngpu_program_vk_init(struct ngpu_program *s, const struct ngpu_program_param
 
         void *data = NULL;
         size_t size = 0;
-        int ret = ngpu_glslang_compile(shaders[i].stage, shaders[i].src, s->gpu_ctx->params.debug, &data, &size);
+        int ret = ngpu_glslang_compile(shaders[i].stage, shaders[i].src, s->gpu_ctx->params.debug, emit_nonsemantic_info, &data, &size);
         if (ret < 0) {
             char *s_with_numbers = ngpu_numbered_lines(shaders[i].src);
             if (s_with_numbers) {

--- a/libngpu/src/vulkan/vkcontext.c
+++ b/libngpu/src/vulkan/vkcontext.c
@@ -62,6 +62,14 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL debug_callback(VkDebugUtilsMessageSeverity
     if (cb_data->messageIdNumber == 0x7cd0911d)
         return VK_FALSE;
 
+    /*
+     * Silence VUID-VkShaderModuleCreateInfo-pCode-08737 as it can be
+     * considered a false positive. It happens when loading shader modules
+     * produced by 16.2.0 in the CI (Ubuntu 24.04).
+     */
+    if (cb_data->messageIdNumber == 0xa5625282)
+        return VK_FALSE;
+
     enum ngpu_log_level level = NGPU_LOG_INFO;
     if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)        level = NGPU_LOG_ERROR;
     else if (severity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT) level = NGPU_LOG_WARNING;

--- a/python/pynopegl/_pynopegl.pyx
+++ b/python/pynopegl/_pynopegl.pyx
@@ -21,8 +21,7 @@
 # under the License.
 #
 
-from cpython cimport array
-from cpython cimport pystate
+from cpython cimport array, pystate
 from libc.stdint cimport int32_t, uint8_t, uint32_t, uintptr_t
 from libc.stdlib cimport calloc, free
 from libc.string cimport memset

--- a/tests/api.py
+++ b/tests/api.py
@@ -383,7 +383,6 @@ def api_text_live_change_with_font():
     return _api_text_live_change(font_faces=[ngl.FontFace(font_faces.as_posix())])
 
 
-
 def api_media_sharing_failure():
     ctx = ngl.Context()
     ret = ctx.configure(ngl.Config(offscreen=True, width=16, height=16, backend=_backend))


### PR DESCRIPTION
Newer glslang versions (>= 16.2.0) may generate SPIR-V containing NonSemantic.Shader.DebugInfo.100 instructions when non-semantic shader debug info is requested. Drivers must advertise
VK_KHR_shader_non_semantic_info and VK_KHR_shader_relaxed_extended_instruction to accept these modules.

Ignores the relevant validation error that is triggered in the CI env.

Fixes shader compilation on the CI (Mesa llvmpipe).