### PR TITLE
ngpu/vk: remove link-time dependency on libvulkan

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -951,6 +951,9 @@ def _ngpu_setup(cfg):
         renderdoc_dir = cfg.externals[_RENDERDOC_ID]
         ngpu_opts += [f"-Drenderdoc_dir={renderdoc_dir}"]
 
+    if cfg.host in ("Darwin", "iOS"):
+        ngpu_opts += ["-Dvulkan-static=enabled"]
+
     extra_library_dirs = []
     extra_include_dirs = []
     if cfg.host == "Windows":

--- a/libngpu/meson.build
+++ b/libngpu/meson.build
@@ -427,6 +427,10 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
   endif
   host_backend_cfg = hosts_backend_cfg.get(host_system)
   gbackend_deps = []
+  # Vulkan is loaded dynamically via dlopen at runtime by default. With
+  # -Dvulkan-static=enabled, libvulkan is linked at build time instead.
+  opt_vulkan_static = get_option('vulkan-static')
+  gbackend_vulkan_static = opt_vulkan_static.enabled()
   foreach dep : host_backend_cfg.get('deps', [])
     if dep == 'glslang'
       add_languages('cpp')
@@ -484,6 +488,23 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
           gbackend_deps += disabler()
         endif
       endif
+    elif dep == 'vulkan'
+      # Default: load Vulkan dynamically via dlopen(libvulkan) at runtime,
+      # only the headers are required at compile time. With -Dvulkan-static=
+      # enabled, link against libvulkan instead.
+      vulkan_dep = dependency('vulkan', required: opt_gbackend)
+      if vulkan_dep.found()
+        if gbackend_vulkan_static
+          gbackend_deps += vulkan_dep
+        else
+          gbackend_deps += declare_dependency(
+            dependencies: vulkan_dep.partial_dependency(includes: true, compile_args: true),
+            compile_args: ['-DVK_NO_PROTOTYPES'],
+          )
+        endif
+      else
+        gbackend_deps += disabler()
+      endif
     else
       gbackend_deps += dependency(dep, required: opt_gbackend)
     endif
@@ -518,6 +539,9 @@ foreach gbackend_name, gbackend_cfg : gbackends_cfg
     conf_data.set10(gbackend_cfg.get('cfg'), true)
     if 'cfg' in host_backend_cfg
       conf_data.set10(host_backend_cfg.get('cfg'), true)
+    endif
+    if gbackend_name == 'vk'
+      conf_data.set10('NGPU_VULKAN_STATIC', gbackend_vulkan_static)
     endif
   endif
 endforeach

--- a/libngpu/meson_options.txt
+++ b/libngpu/meson_options.txt
@@ -22,6 +22,11 @@
 option('gbackend-gl', type: 'feature', value: 'auto')
 option('gbackend-gles', type: 'feature', value: 'auto')
 option('gbackend-vk', type: 'feature', value: 'auto')
+option('vulkan-static', type: 'feature', value: 'auto',
+       description: 'Statically link against libvulkan/libMoltenVK instead of '
+                  + 'loading it dynamically via dlopen at runtime. Defaults to '
+                  + 'enabled on iOS (no system Vulkan loader available) and '
+                  + 'disabled elsewhere.')
 
 option('wayland', type: 'feature', value: 'auto',
        description: 'Wayland support')

--- a/libngpu/src/vulkan/bindgroup_vk.c
+++ b/libngpu/src/vulkan/bindgroup_vk.c
@@ -89,8 +89,8 @@ static void destroy_desc_pool(void *user_data, void *data)
     VkDescriptorPool *desc_pool = data;
     if (!desc_pool)
         return;
-    vkResetDescriptorPool(vk->device, *desc_pool, 0);
-    vkDestroyDescriptorPool(vk->device, *desc_pool, NULL);
+    vk->funcs.ResetDescriptorPool(vk->device, *desc_pool, 0);
+    vk->funcs.DestroyDescriptorPool(vk->device, *desc_pool, NULL);
     *desc_pool = VK_NULL_HANDLE;
 }
 
@@ -118,12 +118,12 @@ static VkResult allocate_desc_pool(struct ngpu_bindgroup_layout *s, uint32_t fac
     };
 
     VkDescriptorPool pool = VK_NULL_HANDLE;
-    VkResult res = vkCreateDescriptorPool(vk->device, &descriptor_pool_create_info, NULL, &pool);
+    VkResult res = vk->funcs.CreateDescriptorPool(vk->device, &descriptor_pool_create_info, NULL, &pool);
     if (res != VK_SUCCESS)
         return res;
 
     if (!ngpu_darray_push(&s_priv->desc_pools, &pool)) {
-        vkDestroyDescriptorPool(vk->device, pool, NULL);
+        vk->funcs.DestroyDescriptorPool(vk->device, pool, NULL);
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     }
 
@@ -210,7 +210,7 @@ static VkResult create_desc_set_layout_bindings(struct ngpu_bindgroup_layout *s)
         .pBindings    = ngpu_darray_data(&s_priv->desc_set_layout_bindings),
     };
 
-    VkResult res = vkCreateDescriptorSetLayout(vk->device, &descriptor_set_layout_create_info, NULL, &s_priv->desc_set_layout);
+    VkResult res = vk->funcs.CreateDescriptorSetLayout(vk->device, &descriptor_set_layout_create_info, NULL, &s_priv->desc_set_layout);
     if (res != VK_SUCCESS)
         return res;
 
@@ -253,7 +253,7 @@ static VkResult ngpu_bindgroup_layout_vk_allocate_set(struct ngpu_bindgroup_layo
             .pSetLayouts        = &s_priv->desc_set_layout,
         };
 
-        VkResult res = vkAllocateDescriptorSets(vk->device, &descriptor_set_allocate_info, desc_set);
+        VkResult res = vk->funcs.AllocateDescriptorSets(vk->device, &descriptor_set_allocate_info, desc_set);
         if (res == VK_SUCCESS) {
             return VK_SUCCESS;
         } else if (res == VK_ERROR_OUT_OF_POOL_MEMORY || res == VK_ERROR_FRAGMENTED_POOL) {
@@ -275,7 +275,7 @@ static VkResult ngpu_bindgroup_layout_vk_allocate_set(struct ngpu_bindgroup_layo
         .pSetLayouts        = &s_priv->desc_set_layout,
     };
 
-    res = vkAllocateDescriptorSets(vk->device, &descriptor_set_allocate_info, desc_set);
+    res = vk->funcs.AllocateDescriptorSets(vk->device, &descriptor_set_allocate_info, desc_set);
     if (res != VK_SUCCESS)
         return res;
 
@@ -305,7 +305,7 @@ void ngpu_bindgroup_layout_vk_freep(struct ngpu_bindgroup_layout **sp)
     ngpu_darray_reset(&s_priv->immutable_samplers);
     ngpu_darray_reset(&s_priv->desc_pools);
 
-    vkDestroyDescriptorSetLayout(vk->device, s_priv->desc_set_layout, NULL);
+    vk->funcs.DestroyDescriptorSetLayout(vk->device, s_priv->desc_set_layout, NULL);
 
     ngpu_freep(sp);
 }
@@ -451,7 +451,7 @@ int ngpu_bindgroup_vk_update_descriptor_set(struct ngpu_bindgroup *s)
                 .descriptorCount  = 1,
                 .pImageInfo       = &image_info,
             };
-            vkUpdateDescriptorSets(vk->device, 1, &write_descriptor_set, 0, NULL);
+            vk->funcs.UpdateDescriptorSets(vk->device, 1, &write_descriptor_set, 0, NULL);
             binding->update_desc = 0;
         }
     }
@@ -479,7 +479,7 @@ int ngpu_bindgroup_vk_update_descriptor_set(struct ngpu_bindgroup *s)
                 .pImageInfo       = NULL,
                 .pTexelBufferView = NULL,
             };
-            vkUpdateDescriptorSets(vk->device, 1, &write_descriptor_set, 0, NULL);
+            vk->funcs.UpdateDescriptorSets(vk->device, 1, &write_descriptor_set, 0, NULL);
             binding->update_desc = 0;
         }
     }

--- a/libngpu/src/vulkan/buffer_vk.c
+++ b/libngpu/src/vulkan/buffer_vk.c
@@ -46,12 +46,12 @@ static VkResult create_vk_buffer(struct vkcontext *vk,
         .usage       = usage,
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
-    VkResult res = vkCreateBuffer(vk->device, &buffer_create_info, NULL, &buffer);
+    VkResult res = vk->funcs.CreateBuffer(vk->device, &buffer_create_info, NULL, &buffer);
     if (res != VK_SUCCESS)
         goto fail;
 
     VkMemoryRequirements mem_reqs;
-    vkGetBufferMemoryRequirements(vk->device, buffer, &mem_reqs);
+    vk->funcs.GetBufferMemoryRequirements(vk->device, buffer, &mem_reqs);
 
     uint32_t mem_type_index = ngpu_vkcontext_find_memory_type(vk, mem_reqs.memoryTypeBits, mem_props);
     if (mem_type_index == UINT32_MAX) {
@@ -69,11 +69,11 @@ static VkResult create_vk_buffer(struct vkcontext *vk,
         .allocationSize  = mem_reqs.size,
         .memoryTypeIndex = mem_type_index,
     };
-    res = vkAllocateMemory(vk->device, &memory_allocate_info, NULL, &memory);
+    res = vk->funcs.AllocateMemory(vk->device, &memory_allocate_info, NULL, &memory);
     if (res != VK_SUCCESS)
         goto fail;
 
-    res = vkBindBufferMemory(vk->device, buffer, memory, 0);
+    res = vk->funcs.BindBufferMemory(vk->device, buffer, memory, 0);
     if (res != VK_SUCCESS)
         goto fail;
 
@@ -83,8 +83,8 @@ static VkResult create_vk_buffer(struct vkcontext *vk,
     return VK_SUCCESS;
 
 fail:
-    vkDestroyBuffer(vk->device, buffer, NULL);
-    vkFreeMemory(vk->device, memory, NULL);
+    vk->funcs.DestroyBuffer(vk->device, buffer, NULL);
+    vk->funcs.FreeMemory(vk->device, memory, NULL);
     return res;
 }
 
@@ -171,11 +171,11 @@ static VkResult buffer_vk_upload(struct ngpu_buffer *s, const void *data, size_t
         s->usage & NGPU_BUFFER_USAGE_MAP_WRITE ||
         s->usage & NGPU_BUFFER_USAGE_DYNAMIC_BIT) {
         void *mapped_data;
-        VkResult res = vkMapMemory(vk->device, s_priv->memory, offset, size, 0, &mapped_data);
+        VkResult res = vk->funcs.MapMemory(vk->device, s_priv->memory, offset, size, 0, &mapped_data);
         if (res != VK_SUCCESS)
             return res;
         memcpy(mapped_data, data, size);
-        vkUnmapMemory(vk->device, s_priv->memory);
+        vk->funcs.UnmapMemory(vk->device, s_priv->memory);
         return VK_SUCCESS;
     }
 
@@ -188,11 +188,11 @@ static VkResult buffer_vk_upload(struct ngpu_buffer *s, const void *data, size_t
         return res;
 
     uint8_t *mapped_data;
-    res = vkMapMemory(vk->device, s_priv->staging_memory, 0, s->size, 0, (void *)&mapped_data);
+    res = vk->funcs.MapMemory(vk->device, s_priv->staging_memory, 0, s->size, 0, (void *)&mapped_data);
     if (res != VK_SUCCESS)
         return res;
     memcpy(mapped_data + offset, data, size);
-    vkUnmapMemory(vk->device, s_priv->staging_memory);
+    vk->funcs.UnmapMemory(vk->device, s_priv->staging_memory);
 
     struct ngpu_cmd_buffer_vk *cmd_buffer_vk;
     res = ngpu_cmd_buffer_vk_begin_transient(s->gpu_ctx, 0, &cmd_buffer_vk);
@@ -204,15 +204,15 @@ static VkResult buffer_vk_upload(struct ngpu_buffer *s, const void *data, size_t
         .dstOffset = offset,
         .size      = size,
     };
-    vkCmdCopyBuffer(cmd_buffer_vk->cmd_buf, s_priv->staging_buffer, s_priv->buffer, 1, &region);
+    vk->funcs.CmdCopyBuffer(cmd_buffer_vk->cmd_buf, s_priv->staging_buffer, s_priv->buffer, 1, &region);
 
     res = ngpu_cmd_buffer_vk_execute_transient(&cmd_buffer_vk);
     if (res != VK_SUCCESS)
         return res;
 
-    vkDestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
+    vk->funcs.DestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
     s_priv->staging_buffer = VK_NULL_HANDLE;
-    vkFreeMemory(vk->device, s_priv->staging_memory, NULL);
+    vk->funcs.FreeMemory(vk->device, s_priv->staging_memory, NULL);
     s_priv->staging_memory = VK_NULL_HANDLE;
 
     return VK_SUCCESS;
@@ -232,7 +232,7 @@ static VkResult buffer_vk_map(struct ngpu_buffer *s, size_t offset, size_t size,
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
     struct ngpu_buffer_vk *s_priv = (struct ngpu_buffer_vk *)s;
 
-    return vkMapMemory(vk->device, s_priv->memory, offset, size, 0, data);
+    return vk->funcs.MapMemory(vk->device, s_priv->memory, offset, size, 0, data);
 }
 
 int ngpu_buffer_vk_map(struct ngpu_buffer *s, size_t offset, size_t size, void **data)
@@ -249,7 +249,7 @@ void ngpu_buffer_vk_unmap(struct ngpu_buffer *s)
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
     struct ngpu_buffer_vk *s_priv = (struct ngpu_buffer_vk *)s;
 
-    vkUnmapMemory(vk->device, s_priv->memory);
+    vk->funcs.UnmapMemory(vk->device, s_priv->memory);
 }
 
 static size_t buffer_vk_find_cmd_buffer(struct ngpu_buffer *s, struct ngpu_cmd_buffer_vk *cmd_buffer)
@@ -307,9 +307,9 @@ void ngpu_buffer_vk_freep(struct ngpu_buffer **sp)
 
     ngpu_darray_reset(&s_priv->cmd_buffers);
 
-    vkDestroyBuffer(vk->device, s_priv->buffer, NULL);
-    vkFreeMemory(vk->device, s_priv->memory, NULL);
-    vkDestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
-    vkFreeMemory(vk->device, s_priv->staging_memory, NULL);
+    vk->funcs.DestroyBuffer(vk->device, s_priv->buffer, NULL);
+    vk->funcs.FreeMemory(vk->device, s_priv->memory, NULL);
+    vk->funcs.DestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
+    vk->funcs.FreeMemory(vk->device, s_priv->staging_memory, NULL);
     ngpu_freep(sp);
 }

--- a/libngpu/src/vulkan/cmd_buffer_vk.c
+++ b/libngpu/src/vulkan/cmd_buffer_vk.c
@@ -42,8 +42,8 @@ static void cmd_buffer_vk_freep(void **sp)
     ngpu_darray_reset(&s->wait_stages);
     ngpu_darray_reset(&s->signal_sems);
 
-    vkFreeCommandBuffers(vk->device, s->pool, 1, &s->cmd_buf);
-    vkDestroyFence(vk->device, s->fence, NULL);
+    vk->funcs.FreeCommandBuffers(vk->device, s->pool, 1, &s->cmd_buf);
+    vk->funcs.DestroyFence(vk->device, s->fence, NULL);
 
     ngpu_freep(sp);
 }
@@ -95,7 +95,7 @@ VkResult ngpu_cmd_buffer_vk_init(struct ngpu_cmd_buffer_vk *s, int type)
         .level              = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
         .commandBufferCount = 1,
     };
-    VkResult res = vkAllocateCommandBuffers(vk->device, &allocate_info, &s->cmd_buf);
+    VkResult res = vk->funcs.AllocateCommandBuffers(vk->device, &allocate_info, &s->cmd_buf);
     if (res != VK_SUCCESS)
         return res;
 
@@ -104,7 +104,7 @@ VkResult ngpu_cmd_buffer_vk_init(struct ngpu_cmd_buffer_vk *s, int type)
         .pNext = NULL,
         .flags = VK_FENCE_CREATE_SIGNALED_BIT,
     };
-    res = vkCreateFence(vk->device, &fence_create_info, NULL, &s->fence);
+    res = vk->funcs.CreateFence(vk->device, &fence_create_info, NULL, &s->fence);
     if (res != VK_SUCCESS)
         return res;
 
@@ -171,13 +171,16 @@ VkResult ngpu_cmd_buffer_vk_begin(struct ngpu_cmd_buffer_vk *s)
     ngpu_darray_clear(&s->wait_stages);
     ngpu_darray_clear(&s->signal_sems);
 
-    vkResetCommandBuffer(s->cmd_buf, 0);
+    struct ngpu_ctx_vk *gpu_ctx_vk = (struct ngpu_ctx_vk *)s->gpu_ctx;
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+
+    vk->funcs.ResetCommandBuffer(s->cmd_buf, 0);
 
     const VkCommandBufferBeginInfo cmd_buf_begin_info = {
         .sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
         .flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT,
     };
-    return vkBeginCommandBuffer(s->cmd_buf, &cmd_buf_begin_info);
+    return vk->funcs.BeginCommandBuffer(s->cmd_buf, &cmd_buf_begin_info);
 }
 
 VkResult ngpu_cmd_buffer_vk_submit(struct ngpu_cmd_buffer_vk *s)
@@ -185,11 +188,11 @@ VkResult ngpu_cmd_buffer_vk_submit(struct ngpu_cmd_buffer_vk *s)
     struct ngpu_ctx_vk *gpu_ctx_vk = (struct ngpu_ctx_vk *)s->gpu_ctx;
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
 
-    VkResult res = vkEndCommandBuffer(s->cmd_buf);
+    VkResult res = vk->funcs.EndCommandBuffer(s->cmd_buf);
     if (res != VK_SUCCESS)
         return res;
 
-    res = vkResetFences(vk->device, 1, &s->fence);
+    res = vk->funcs.ResetFences(vk->device, 1, &s->fence);
     if (res != VK_SUCCESS)
         return res;
 
@@ -204,7 +207,7 @@ VkResult ngpu_cmd_buffer_vk_submit(struct ngpu_cmd_buffer_vk *s)
         .pSignalSemaphores    = ngpu_darray_data(&s->signal_sems),
     };
 
-    res = vkQueueSubmit(vk->graphic_queue, 1, &submit_info, s->fence);
+    res = vk->funcs.QueueSubmit(vk->graphic_queue, 1, &submit_info, s->fence);
     if (res != VK_SUCCESS)
         return res;
 
@@ -226,7 +229,7 @@ VkResult ngpu_cmd_buffer_vk_wait(struct ngpu_cmd_buffer_vk *s)
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
 
     if (s->submitted) {
-        VkResult res = vkWaitForFences(vk->device, 1, &s->fence, VK_TRUE, UINT64_MAX);
+        VkResult res = vk->funcs.WaitForFences(vk->device, 1, &s->fence, VK_TRUE, UINT64_MAX);
         if (res != VK_SUCCESS)
             return res;
     }

--- a/libngpu/src/vulkan/ctx_vk.c
+++ b/libngpu/src/vulkan/ctx_vk.c
@@ -295,7 +295,7 @@ static VkResult create_query_pool(struct ngpu_ctx *s)
         .queryCount = 2,
     };
 
-    return vkCreateQueryPool(vk->device, &create_info, NULL, &s_priv->query_pool);
+    return vk->funcs.CreateQueryPool(vk->device, &create_info, NULL, &s_priv->query_pool);
 }
 
 static void destroy_query_pool(struct ngpu_ctx *s)
@@ -303,7 +303,7 @@ static void destroy_query_pool(struct ngpu_ctx *s)
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)s;
     struct vkcontext *vk = s_priv->vkcontext;
 
-    vkDestroyQueryPool(vk->device, s_priv->query_pool, NULL);
+    vk->funcs.DestroyQueryPool(vk->device, s_priv->query_pool, NULL);
 }
 
 static VkResult create_command_pool_and_buffers(struct ngpu_ctx *s)
@@ -317,7 +317,7 @@ static VkResult create_command_pool_and_buffers(struct ngpu_ctx *s)
         .flags            = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT,
     };
 
-    VkResult res = vkCreateCommandPool(vk->device, &cmd_pool_create_info, NULL, &s_priv->cmd_pool);
+    VkResult res = vk->funcs.CreateCommandPool(vk->device, &cmd_pool_create_info, NULL, &s_priv->cmd_pool);
     if (res != VK_SUCCESS)
         return res;
 
@@ -364,7 +364,7 @@ static void destroy_command_pool_and_buffers(struct ngpu_ctx *s)
         ngpu_freep(&s_priv->update_cmd_buffers);
     }
 
-    vkDestroyCommandPool(vk->device, s_priv->cmd_pool, NULL);
+    vk->funcs.DestroyCommandPool(vk->device, s_priv->cmd_pool, NULL);
 
     ngpu_darray_reset(&s_priv->pending_cmd_buffers);
 }
@@ -384,7 +384,7 @@ static VkResult create_semaphores(struct ngpu_ctx *s)
 
     VkResult res;
     for (uint32_t i = 0; i < s->nb_in_flight_frames; i++) {
-        if ((res = vkCreateSemaphore(vk->device, &sem_create_info, NULL,
+        if ((res = vk->funcs.CreateSemaphore(vk->device, &sem_create_info, NULL,
                                      &s_priv->update_finished_sems[i])) != VK_SUCCESS)
             return res;
     }
@@ -401,7 +401,7 @@ static void destroy_semaphores(struct ngpu_ctx *s)
 
     if (s_priv->update_finished_sems) {
         for (uint32_t i = 0; i < s->nb_in_flight_frames; i++)
-            vkDestroySemaphore(vk->device, s_priv->update_finished_sems[i], NULL);
+            vk->funcs.DestroySemaphore(vk->device, s_priv->update_finished_sems[i], NULL);
         ngpu_freep(&s_priv->update_finished_sems);
     }
 
@@ -427,9 +427,9 @@ static VkResult create_swapchain_semaphores(struct ngpu_ctx *s)
 
     VkResult res;
     for (uint32_t i = 0; i < s_priv->nb_images; i++) {
-        if ((res = vkCreateSemaphore(vk->device, &sem_create_info, NULL,
+        if ((res = vk->funcs.CreateSemaphore(vk->device, &sem_create_info, NULL,
                                      &s_priv->image_avail_sems[i])) != VK_SUCCESS ||
-            (res = vkCreateSemaphore(vk->device, &sem_create_info, NULL,
+            (res = vk->funcs.CreateSemaphore(vk->device, &sem_create_info, NULL,
                                      &s_priv->image_present_sems[i])) != VK_SUCCESS)
             return res;
     }
@@ -444,13 +444,13 @@ static void destroy_swapchain_semaphores(struct ngpu_ctx *s)
 
     if (s_priv->image_avail_sems) {
         for (uint32_t i = 0; i < s_priv->nb_images; i++)
-            vkDestroySemaphore(vk->device, s_priv->image_avail_sems[i], NULL);
+            vk->funcs.DestroySemaphore(vk->device, s_priv->image_avail_sems[i], NULL);
         ngpu_freep(&s_priv->image_avail_sems);
     }
 
     if (s_priv->image_present_sems) {
         for (uint32_t i = 0; i < s_priv->nb_images; i++)
-            vkDestroySemaphore(vk->device, s_priv->image_present_sems[i], NULL);
+            vk->funcs.DestroySemaphore(vk->device, s_priv->image_present_sems[i], NULL);
         ngpu_freep(&s_priv->image_present_sems);
     }
 }
@@ -535,7 +535,7 @@ static VkResult create_swapchain(struct ngpu_ctx *s)
     struct vkcontext *vk = s_priv->vkcontext;
     struct ngpu_ctx_params *ctx_params = &s->params;
 
-    VkResult res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->phy_device, vk->surface, &s_priv->surface_caps);
+    VkResult res = vk->funcs.GetPhysicalDeviceSurfaceCapabilitiesKHR(vk->phy_device, vk->surface, &s_priv->surface_caps);
     if (res != VK_SUCCESS)
         return res;
 
@@ -585,11 +585,11 @@ static VkResult create_swapchain(struct ngpu_ctx *s)
         swapchain_create_info.pQueueFamilyIndices = queue_family_indices;
     }
 
-    res = vkCreateSwapchainKHR(vk->device, &swapchain_create_info, NULL, &s_priv->swapchain);
+    res = vk->funcs.CreateSwapchainKHR(vk->device, &swapchain_create_info, NULL, &s_priv->swapchain);
     if (res != VK_SUCCESS)
         return res;
 
-    res = vkGetSwapchainImagesKHR(vk->device, s_priv->swapchain, &s_priv->nb_images, NULL);
+    res = vk->funcs.GetSwapchainImagesKHR(vk->device, s_priv->swapchain, &s_priv->nb_images, NULL);
     if (res != VK_SUCCESS)
         return res;
 
@@ -598,7 +598,7 @@ static VkResult create_swapchain(struct ngpu_ctx *s)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
     s_priv->images = images;
 
-    res = vkGetSwapchainImagesKHR(vk->device, s_priv->swapchain, &s_priv->nb_images, s_priv->images);
+    res = vk->funcs.GetSwapchainImagesKHR(vk->device, s_priv->swapchain, &s_priv->nb_images, s_priv->images);
     if (res != VK_SUCCESS)
         return res;
 
@@ -612,7 +612,7 @@ static void destroy_swapchain(struct ngpu_ctx *s)
 
     destroy_swapchain_semaphores(s);
 
-    vkDestroySwapchainKHR(vk->device, s_priv->swapchain, NULL);
+    vk->funcs.DestroySwapchainKHR(vk->device, s_priv->swapchain, NULL);
     s_priv->swapchain = VK_NULL_HANDLE;
 
     ngpu_freep(&s_priv->images);
@@ -623,12 +623,12 @@ static VkResult recreate_swapchain(struct ngpu_ctx *gpu_ctx, struct vkcontext *v
 {
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)gpu_ctx;
 
-    VkResult res = vkDeviceWaitIdle(vk->device);
+    VkResult res = vk->funcs.DeviceWaitIdle(vk->device);
     if (res != VK_SUCCESS)
         return res;
 
     VkSurfaceCapabilitiesKHR surface_caps;
-    res = vkGetPhysicalDeviceSurfaceCapabilitiesKHR(vk->phy_device, vk->surface, &surface_caps);
+    res = vk->funcs.GetPhysicalDeviceSurfaceCapabilitiesKHR(vk->phy_device, vk->surface, &surface_caps);
     if (res != VK_SUCCESS)
         return res;
 
@@ -668,7 +668,7 @@ static VkResult swapchain_acquire_image(struct ngpu_ctx *s, uint32_t *image_inde
     }
 
     VkSemaphore sem = s_priv->image_avail_sems[s->current_frame_index];
-    VkResult res = vkAcquireNextImageKHR(vk->device, s_priv->swapchain,
+    VkResult res = vk->funcs.AcquireNextImageKHR(vk->device, s_priv->swapchain,
                                          UINT64_MAX, sem, VK_NULL_HANDLE, image_index);
     switch (res) {
     case VK_SUCCESS:
@@ -679,7 +679,7 @@ static VkResult swapchain_acquire_image(struct ngpu_ctx *s, uint32_t *image_inde
         if (res != VK_SUCCESS)
             return res;
 
-        res = vkAcquireNextImageKHR(vk->device, s_priv->swapchain,
+        res = vk->funcs.AcquireNextImageKHR(vk->device, s_priv->swapchain,
                                     UINT64_MAX, sem, VK_NULL_HANDLE, image_index);
         if (res != VK_SUCCESS)
             return res;
@@ -745,7 +745,7 @@ static VkResult swapchain_present_buffer(struct ngpu_ctx *s, double t)
         present_info.pNext = &present_time_info;
     }
 
-    VkResult res = vkQueuePresentKHR(vk->present_queue, &present_info);
+    VkResult res = vk->funcs.QueuePresentKHR(vk->present_queue, &present_info);
     switch (res) {
     case VK_SUCCESS:
     case VK_SUBOPTIMAL_KHR:
@@ -1125,8 +1125,9 @@ static int vk_begin_draw(struct ngpu_ctx *s)
     }
 
     if (ctx_params->timer_queries) {
-        vkCmdResetQueryPool(s_priv->cur_cmd_buffer->cmd_buf, s_priv->query_pool, 0, 2);
-        vkCmdWriteTimestamp(s_priv->cur_cmd_buffer->cmd_buf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, s_priv->query_pool, 0);
+        struct vkcontext *vk = s_priv->vkcontext;
+        vk->funcs.CmdResetQueryPool(s_priv->cur_cmd_buffer->cmd_buf, s_priv->query_pool, 0, 2);
+        vk->funcs.CmdWriteTimestamp(s_priv->cur_cmd_buffer->cmd_buf, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, s_priv->query_pool, 0);
     }
 
     return 0;
@@ -1143,7 +1144,7 @@ static int vk_query_draw_time(struct ngpu_ctx *s, int64_t *time)
 
     ngpu_assert(s_priv->cur_cmd_buffer->cmd_buf);
     VkCommandBuffer cmd_buf = s_priv->cur_cmd_buffer->cmd_buf;
-    vkCmdWriteTimestamp(cmd_buf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, s_priv->query_pool, 1);
+    vk->funcs.CmdWriteTimestamp(cmd_buf, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, s_priv->query_pool, 1);
 
     VkResult res = ngpu_cmd_buffer_vk_submit(s_priv->cur_cmd_buffer);
     if (res != VK_SUCCESS)
@@ -1154,7 +1155,7 @@ static int vk_query_draw_time(struct ngpu_ctx *s, int64_t *time)
         return ngpu_vk_res2ret(res);
 
     uint64_t results[2];
-    vkGetQueryPoolResults(vk->device,
+    vk->funcs.GetQueryPoolResults(vk->device,
                           s_priv->query_pool, 0, 2,
                           sizeof(results), results, sizeof(results[0]),
                           VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
@@ -1218,7 +1219,7 @@ static void vk_destroy(struct ngpu_ctx *s)
     if (!vk)
         return;
 
-    vkDeviceWaitIdle(vk->device);
+    vk->funcs.DeviceWaitIdle(vk->device);
 
 #if DEBUG_GPU_CAPTURE
     if (s->gpu_capture)
@@ -1242,7 +1243,7 @@ static void vk_wait_idle(struct ngpu_ctx *s)
 {
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)s;
     struct vkcontext *vk = s_priv->vkcontext;
-    vkDeviceWaitIdle(vk->device);
+    vk->funcs.DeviceWaitIdle(vk->device);
 }
 
 static enum ngpu_cull_mode vk_get_cull_mode(struct ngpu_ctx *s, enum ngpu_cull_mode cull_mode)
@@ -1350,7 +1351,8 @@ static void vk_begin_render_pass(struct ngpu_ctx *s, struct ngpu_rendertarget *r
         .clearValueCount = rt_vk->nb_clear_values,
         .pClearValues    = rt_vk->clear_values,
     };
-    vkCmdBeginRenderPass(cmd_buf, &render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
+    struct vkcontext *vk = s_priv->vkcontext;
+    vk->funcs.CmdBeginRenderPass(cmd_buf, &render_pass_begin_info, VK_SUBPASS_CONTENTS_INLINE);
 
     const VkViewport viewport = {
         .x        = 0.f,
@@ -1360,7 +1362,7 @@ static void vk_begin_render_pass(struct ngpu_ctx *s, struct ngpu_rendertarget *r
         .minDepth = 0.f,
         .maxDepth = 1.f,
     };
-    vkCmdSetViewport(cmd_buf, 0, 1, &viewport);
+    vk->funcs.CmdSetViewport(cmd_buf, 0, 1, &viewport);
 
     const VkRect2D scissor = {
         .offset.x      = 0,
@@ -1368,17 +1370,18 @@ static void vk_begin_render_pass(struct ngpu_ctx *s, struct ngpu_rendertarget *r
         .extent.width  = rt->width,
         .extent.height = rt->height,
     };
-    vkCmdSetScissor(cmd_buf, 0, 1, &scissor);
+    vk->funcs.CmdSetScissor(cmd_buf, 0, 1, &scissor);
 
-    vkCmdSetLineWidth(cmd_buf, 1.0f);
+    vk->funcs.CmdSetLineWidth(cmd_buf, 1.0f);
 }
 
 static void vk_end_render_pass(struct ngpu_ctx *s)
 {
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)s;
 
+    struct vkcontext *vk = s_priv->vkcontext;
     VkCommandBuffer cmd_buf = s_priv->cur_cmd_buffer->cmd_buf;
-    vkCmdEndRenderPass(cmd_buf);
+    vk->funcs.CmdEndRenderPass(cmd_buf);
 
     const struct ngpu_rendertarget *rt = s->rendertarget;
     const struct ngpu_rendertarget_params *params = &rt->params;
@@ -1410,6 +1413,7 @@ static void vk_end_render_pass(struct ngpu_ctx *s)
 static void vk_set_viewport(struct ngpu_ctx *s, const struct ngpu_viewport *viewport)
 {
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)s;
+    struct vkcontext *vk = s_priv->vkcontext;
     VkCommandBuffer cmd_buf = s_priv->cur_cmd_buffer->cmd_buf;
 
     const VkViewport vp = {
@@ -1420,12 +1424,13 @@ static void vk_set_viewport(struct ngpu_ctx *s, const struct ngpu_viewport *view
         .minDepth = 0.f,
         .maxDepth = 1.f,
     };
-    vkCmdSetViewport(cmd_buf, 0, 1, &vp);
+    vk->funcs.CmdSetViewport(cmd_buf, 0, 1, &vp);
 }
 
 static void vk_set_scissor(struct ngpu_ctx *s, const struct ngpu_scissor *scissor)
 {
     struct ngpu_ctx_vk *s_priv = (struct ngpu_ctx_vk *)s;
+    struct vkcontext *vk = s_priv->vkcontext;
     VkCommandBuffer cmd_buf = s_priv->cur_cmd_buffer->cmd_buf;
 
     struct ngpu_rendertarget *rt = s->rendertarget;
@@ -1436,7 +1441,7 @@ static void vk_set_scissor(struct ngpu_ctx *s, const struct ngpu_scissor *scisso
         .extent.width  = scissor->width,
         .extent.height = scissor->height,
     };
-    vkCmdSetScissor(cmd_buf, 0, 1, &sc);
+    vk->funcs.CmdSetScissor(cmd_buf, 0, 1, &sc);
 }
 
 static enum ngpu_format vk_get_preferred_depth_format(struct ngpu_ctx *s)
@@ -1460,7 +1465,7 @@ static uint32_t vk_get_format_features(struct ngpu_ctx *s, enum ngpu_format form
 
     VkFormat vk_format = ngpu_format_ngl_to_vk(format);
     VkFormatProperties properties;
-    vkGetPhysicalDeviceFormatProperties(vk->phy_device, vk_format, &properties);
+    vk->funcs.GetPhysicalDeviceFormatProperties(vk->phy_device, vk_format, &properties);
 
     return ngpu_format_feature_vk_to_ngl(properties.optimalTilingFeatures);
 }
@@ -1512,7 +1517,8 @@ static void vk_set_vertex_buffer(struct ngpu_ctx *s, uint32_t index, const struc
     const struct ngpu_buffer_vk *buffer_vk = (const struct ngpu_buffer_vk *)buffer;
     const VkBuffer vertex_buffer = buffer_vk->buffer;
     const VkDeviceSize vertex_offset = 0;
-    vkCmdBindVertexBuffers(cmd_buf, index, 1, &vertex_buffer, &vertex_offset);
+    struct vkcontext *vk = s_priv->vkcontext;
+    vk->funcs.CmdBindVertexBuffers(cmd_buf, index, 1, &vertex_buffer, &vertex_offset);
 }
 
 static const VkIndexType vk_indices_type_map[NGPU_FORMAT_NB] = {
@@ -1537,7 +1543,8 @@ static void vk_set_index_buffer(struct ngpu_ctx *s, const struct ngpu_buffer *bu
     VkCommandBuffer cmd_buf = cmd_buffer->cmd_buf;
     const struct ngpu_buffer_vk *index_buffer = (const struct ngpu_buffer_vk *)buffer;
     const VkIndexType indices_type = get_vk_indices_type(format);
-    vkCmdBindIndexBuffer(cmd_buf, index_buffer->buffer, 0, indices_type);
+    struct vkcontext *vk = s_priv->vkcontext;
+    vk->funcs.CmdBindIndexBuffer(cmd_buf, index_buffer->buffer, 0, indices_type);
 }
 
 VkDevice ngpu_ctx_vk_get_device(struct ngpu_ctx *s)

--- a/libngpu/src/vulkan/pipeline_vk.c
+++ b/libngpu/src/vulkan/pipeline_vk.c
@@ -333,9 +333,9 @@ static VkResult pipeline_graphics_init(struct ngpu_pipeline *s)
         .renderPass          = render_pass,
         .subpass             = 0,
     };
-    res = vkCreateGraphicsPipelines(vk->device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &s_priv->pipeline);
+    res = vk->funcs.CreateGraphicsPipelines(vk->device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &s_priv->pipeline);
 
-    vkDestroyRenderPass(vk->device, render_pass, NULL);
+    vk->funcs.DestroyRenderPass(vk->device, render_pass, NULL);
 
     return res;
 }
@@ -362,7 +362,7 @@ static VkResult pipeline_compute_init(struct ngpu_pipeline *s)
         .layout = s_priv->pipeline_layout,
     };
 
-    return vkCreateComputePipelines(vk->device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &s_priv->pipeline);
+    return vk->funcs.CreateComputePipelines(vk->device, VK_NULL_HANDLE, 1, &pipeline_create_info, NULL, &s_priv->pipeline);
 }
 
 static VkResult create_pipeline_layout(struct ngpu_pipeline *s)
@@ -379,7 +379,7 @@ static VkResult create_pipeline_layout(struct ngpu_pipeline *s)
         .pSetLayouts    = &layout->desc_set_layout,
     };
 
-    return vkCreatePipelineLayout(vk->device, &pipeline_layout_create_info, NULL, &s_priv->pipeline_layout);
+    return vk->funcs.CreatePipelineLayout(vk->device, &pipeline_layout_create_info, NULL, &s_priv->pipeline_layout);
 }
 
 static VkResult create_pipeline(struct ngpu_pipeline *s)
@@ -446,7 +446,8 @@ static int prepare_and_bind_descriptor_set(struct ngpu_pipeline *s, VkCommandBuf
             struct buffer_binding_vk *binding = &bindings[i];
             ngpu_cmd_buffer_vk_ref_buffer(cmd_buffer_vk, (struct ngpu_buffer *)binding->buffer);
         }
-        vkCmdBindDescriptorSets(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline_layout, 0,
+        struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+        vk->funcs.CmdBindDescriptorSets(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline_layout, 0,
                                 1, &bindgroup_vk->desc_set,
                                 (uint32_t)gpu_ctx->nb_dynamic_offsets, gpu_ctx->dynamic_offsets);
     }
@@ -458,7 +459,9 @@ static int prepare_and_bind_graphics_pipeline(struct ngpu_pipeline *s, VkCommand
 {
     struct ngpu_pipeline_vk *s_priv = (struct ngpu_pipeline_vk *)s;
 
-    vkCmdBindPipeline(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline);
+    struct ngpu_ctx_vk *gpu_ctx_vk2 = (struct ngpu_ctx_vk *)s->gpu_ctx;
+    struct vkcontext *vk = gpu_ctx_vk2->vkcontext;
+    vk->funcs.CmdBindPipeline(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline);
 
     return 0;
 }
@@ -479,7 +482,8 @@ void ngpu_pipeline_vk_draw(struct ngpu_pipeline *s, uint32_t nb_vertices, uint32
     if (ret < 0)
         return;
 
-    vkCmdDraw(cmd_buf, nb_vertices, nb_instances, first_vertex, 0);
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    vk->funcs.CmdDraw(cmd_buf, nb_vertices, nb_instances, first_vertex, 0);
 }
 
 void ngpu_pipeline_vk_draw_indexed(struct ngpu_pipeline *s, uint32_t nb_vertices, uint32_t nb_instances, uint32_t first_index)
@@ -497,7 +501,8 @@ void ngpu_pipeline_vk_draw_indexed(struct ngpu_pipeline *s, uint32_t nb_vertices
     if (ret < 0)
         return;
 
-    vkCmdDrawIndexed(cmd_buf, nb_vertices, nb_instances, first_index, 0, 0);
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    vk->funcs.CmdDrawIndexed(cmd_buf, nb_vertices, nb_instances, first_index, 0, 0);
 }
 
 void ngpu_pipeline_vk_dispatch(struct ngpu_pipeline *s, uint32_t nb_group_x, uint32_t nb_group_y, uint32_t nb_group_z)
@@ -519,8 +524,9 @@ void ngpu_pipeline_vk_dispatch(struct ngpu_pipeline *s, uint32_t nb_group_x, uin
     if (ret < 0)
         return;
 
-    vkCmdBindPipeline(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline);
-    vkCmdDispatch(cmd_buf, nb_group_x, nb_group_y, nb_group_z);
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    vk->funcs.CmdBindPipeline(cmd_buf, s_priv->pipeline_bind_point, s_priv->pipeline);
+    vk->funcs.CmdDispatch(cmd_buf, nb_group_x, nb_group_y, nb_group_z);
 
     const VkMemoryBarrier barrier = {
         .sType         = VK_STRUCTURE_TYPE_MEMORY_BARRIER,
@@ -538,7 +544,7 @@ void ngpu_pipeline_vk_dispatch(struct ngpu_pipeline *s, uint32_t nb_group_x, uin
     };
     const VkPipelineStageFlags src_stage = VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT;
     const VkPipelineStageFlags dst_stage = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
-    vkCmdPipelineBarrier(cmd_buf, src_stage, dst_stage, 0, 1, &barrier, 0, NULL, 0, NULL);
+    vk->funcs.CmdPipelineBarrier(cmd_buf, src_stage, dst_stage, 0, 1, &barrier, 0, NULL, 0, NULL);
 
     if (cmd_is_transient) {
         ngpu_cmd_buffer_vk_execute_transient(&cmd_buffer_vk);
@@ -558,8 +564,8 @@ void ngpu_pipeline_vk_freep(struct ngpu_pipeline **sp)
 
     struct ngpu_ctx_vk *gpu_ctx_vk = (struct ngpu_ctx_vk *)s->gpu_ctx;
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
-    vkDestroyPipeline(vk->device, s_priv->pipeline, NULL);
-    vkDestroyPipelineLayout(vk->device, s_priv->pipeline_layout, NULL);
+    vk->funcs.DestroyPipeline(vk->device, s_priv->pipeline, NULL);
+    vk->funcs.DestroyPipelineLayout(vk->device, s_priv->pipeline_layout, NULL);
 
     ngpu_freep(sp);
 }

--- a/libngpu/src/vulkan/program_vk.c
+++ b/libngpu/src/vulkan/program_vk.c
@@ -86,7 +86,7 @@ int ngpu_program_vk_init(struct ngpu_program *s, const struct ngpu_program_param
             .codeSize = size,
             .pCode    = data,
         };
-        VkResult res = vkCreateShaderModule(vk->device, &shader_module_create_info, NULL, &s_priv->shaders[i]);
+        VkResult res = vk->funcs.CreateShaderModule(vk->device, &shader_module_create_info, NULL, &s_priv->shaders[i]);
         ngpu_freep(&data);
         if (res != VK_SUCCESS) {
             char *s_with_numbers = ngpu_numbered_lines(shaders[i].src);
@@ -113,6 +113,6 @@ void ngpu_program_vk_freep(struct ngpu_program **sp)
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
 
     for (size_t i = 0; i < NGPU_ARRAY_NB(s_priv->shaders); i++)
-        vkDestroyShaderModule(vk->device, s_priv->shaders[i], NULL);
+        vk->funcs.DestroyShaderModule(vk->device, s_priv->shaders[i], NULL);
     ngpu_freep(sp);
 }

--- a/libngpu/src/vulkan/rendertarget_vk.c
+++ b/libngpu/src/vulkan/rendertarget_vk.c
@@ -84,7 +84,7 @@ static VkResult vk_create_compatible_renderpass(struct ngpu_ctx *s, const struct
         VkFormat format = ngpu_format_ngl_to_vk(layout->colors[i].format);
 
         VkFormatProperties properties;
-        vkGetPhysicalDeviceFormatProperties(vk->phy_device, format, &properties);
+        vk->funcs.GetPhysicalDeviceFormatProperties(vk->phy_device, format, &properties);
 
         const VkFormatFeatureFlags features = VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
         if ((properties.optimalTilingFeatures & features) != features) {
@@ -137,7 +137,7 @@ static VkResult vk_create_compatible_renderpass(struct ngpu_ctx *s, const struct
         VkFormat format = ngpu_format_ngl_to_vk(layout->depth_stencil.format);
 
         VkFormatProperties properties;
-        vkGetPhysicalDeviceFormatProperties(vk->phy_device, format, &properties);
+        vk->funcs.GetPhysicalDeviceFormatProperties(vk->phy_device, format, &properties);
 
         const VkFormatFeatureFlags features = VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT;
         if ((properties.optimalTilingFeatures & features) != features) {
@@ -210,7 +210,7 @@ static VkResult vk_create_compatible_renderpass(struct ngpu_ctx *s, const struct
         .pDependencies   = dependencies,
     };
 
-    return vkCreateRenderPass(vk->device, &render_pass_create_info, NULL, render_pass);
+    return vk->funcs.CreateRenderPass(vk->device, &render_pass_create_info, NULL, render_pass);
 }
 
 VkResult ngpu_vk_create_compatible_renderpass(struct ngpu_ctx *s, const struct ngpu_rendertarget_layout *layout, VkRenderPass *render_pass)
@@ -264,7 +264,7 @@ static VkResult create_image_view(const struct ngpu_rendertarget *s, const struc
             .layerCount     = 1,
         },
     };
-    return vkCreateImageView(vk->device, &view_info, NULL, view);
+    return vk->funcs.CreateImageView(vk->device, &view_info, NULL, view);
 }
 
 static VkResult add_attachment(struct ngpu_rendertarget *s, const struct ngpu_texture *texture, uint32_t layer, const VkClearValue *clear_value)
@@ -344,7 +344,7 @@ static VkResult rendertarget_vk_init(struct ngpu_rendertarget *s)
         .layers          = 1,
     };
 
-    return vkCreateFramebuffer(vk->device, &framebuffer_create_info, NULL, &s_priv->framebuffer);
+    return vk->funcs.CreateFramebuffer(vk->device, &framebuffer_create_info, NULL, &s_priv->framebuffer);
 }
 
 int ngpu_rendertarget_vk_init(struct ngpu_rendertarget *s)
@@ -365,16 +365,16 @@ void ngpu_rendertarget_vk_freep(struct ngpu_rendertarget **sp)
     struct ngpu_ctx_vk *gpu_ctx_vk = (struct ngpu_ctx_vk *)s->gpu_ctx;
 
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
-    vkDestroyRenderPass(vk->device, s_priv->render_pass, NULL);
-    vkDestroyFramebuffer(vk->device, s_priv->framebuffer, NULL);
+    vk->funcs.DestroyRenderPass(vk->device, s_priv->render_pass, NULL);
+    vk->funcs.DestroyFramebuffer(vk->device, s_priv->framebuffer, NULL);
 
     for (uint32_t i = 0; i < s_priv->nb_attachments; i++) {
-        vkDestroyImageView(vk->device, s_priv->attachments[i], NULL);
+        vk->funcs.DestroyImageView(vk->device, s_priv->attachments[i], NULL);
         NGPU_RC_UNREFP(&s_priv->attachments_refs[i]);
     }
 
-    vkDestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
-    vkFreeMemory(vk->device, s_priv->staging_memory, NULL);
+    vk->funcs.DestroyBuffer(vk->device, s_priv->staging_buffer, NULL);
+    vk->funcs.FreeMemory(vk->device, s_priv->staging_memory, NULL);
 
     ngpu_freep(sp);
 }

--- a/libngpu/src/vulkan/texture_vk.c
+++ b/libngpu/src/vulkan/texture_vk.c
@@ -186,7 +186,8 @@ static VkAccessFlagBits get_vk_access_mask_from_image_layout(VkImageLayout layou
     return access_mask;
 }
 
-static void transition_image_layout(VkCommandBuffer cmd_buf,
+static void transition_image_layout(const struct vk_functions *funcs,
+                                    VkCommandBuffer cmd_buf,
                                     VkImage image,
                                     VkImageLayout old_layout,
                                     VkImageLayout new_layout,
@@ -207,7 +208,7 @@ static void transition_image_layout(VkCommandBuffer cmd_buf,
         .subresourceRange    = *subres_range,
     };
 
-    vkCmdPipelineBarrier(cmd_buf, src_stage, dst_stage, 0, 0, NULL, 0, NULL, 1, &barrier);
+    funcs->CmdPipelineBarrier(cmd_buf, src_stage, dst_stage, 0, 0, NULL, 0, NULL, 1, &barrier);
 }
 
 VkImageUsageFlags ngpu_vk_get_image_usage_flags(uint32_t usage)
@@ -312,7 +313,7 @@ static VkResult create_image_view(struct ngpu_texture *s)
         }
     };
 
-    return vkCreateImageView(vk->device, &view_info, NULL, &s_priv->image_view);
+    return vk->funcs.CreateImageView(vk->device, &view_info, NULL, &s_priv->image_view);
 }
 
 static VkResult create_sampler(struct ngpu_texture *s)
@@ -339,7 +340,7 @@ static VkResult create_sampler(struct ngpu_texture *s)
         .maxLod                  = (float)s_priv->mipmap_levels,
         .mipLodBias              = 0.0f,
     };
-    return vkCreateSampler(vk->device, &sampler_info, NULL, &s_priv->sampler);
+    return vk->funcs.CreateSampler(vk->device, &sampler_info, NULL, &s_priv->sampler);
 }
 
 struct ngpu_texture *ngpu_texture_vk_create(struct ngpu_ctx *gpu_ctx)
@@ -362,7 +363,7 @@ static VkResult texture_vk_init(struct ngpu_texture *s, const struct ngpu_textur
         return res;
 
     VkFormatProperties properties;
-    vkGetPhysicalDeviceFormatProperties(vk->phy_device, s_priv->format, &properties);
+    vk->funcs.GetPhysicalDeviceFormatProperties(vk->phy_device, s_priv->format, &properties);
     const VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
 
     VkFormatFeatureFlags supported_features;
@@ -404,14 +405,14 @@ static VkResult texture_vk_init(struct ngpu_texture *s, const struct ngpu_textur
         .flags         = flags,
     };
 
-    res = vkCreateImage(vk->device, &image_create_info, NULL, &s_priv->image);
+    res = vk->funcs.CreateImage(vk->device, &image_create_info, NULL, &s_priv->image);
     if (res != VK_SUCCESS)
        return res;
 
     s_priv->image_layout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkMemoryRequirements mem_reqs;
-    vkGetImageMemoryRequirements(vk->device, s_priv->image, &mem_reqs);
+    vk->funcs.GetImageMemoryRequirements(vk->device, s_priv->image, &mem_reqs);
 
     uint32_t mem_type_index = UINT32_MAX;
     if (s->params.usage & NGPU_TEXTURE_USAGE_TRANSIENT_ATTACHMENT_BIT) {
@@ -432,11 +433,11 @@ static VkResult texture_vk_init(struct ngpu_texture *s, const struct ngpu_textur
         .allocationSize  = mem_reqs.size,
         .memoryTypeIndex = mem_type_index,
     };
-    res = vkAllocateMemory(vk->device, &alloc_info, NULL, &s_priv->image_memory);
+    res = vk->funcs.AllocateMemory(vk->device, &alloc_info, NULL, &s_priv->image_memory);
     if (res != VK_SUCCESS)
         return res;
 
-    res = vkBindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
+    res = vk->funcs.BindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
     if (res != VK_SUCCESS)
         return res;
 
@@ -453,7 +454,7 @@ static VkResult texture_vk_init(struct ngpu_texture *s, const struct ngpu_textur
         .layerCount     = VK_REMAINING_ARRAY_LAYERS,
     };
 
-    transition_image_layout(cmd_buffer_vk->cmd_buf,
+    transition_image_layout(&vk->funcs, cmd_buffer_vk->cmd_buf,
                             s_priv->image,
                             s_priv->image_layout,
                             s_priv->default_image_layout,
@@ -553,7 +554,7 @@ static int import_dma_buf(struct ngpu_texture *s)
         .sType = VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2_KHR,
     };
 
-    VkResult res = vkGetPhysicalDeviceImageFormatProperties2(vk->phy_device, &fmt_info, &fmt_props);
+    VkResult res = vk->funcs.GetPhysicalDeviceImageFormatProperties2(vk->phy_device, &fmt_info, &fmt_props);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not get image format properties: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -566,7 +567,7 @@ static int import_dma_buf(struct ngpu_texture *s)
         return NGPU_ERROR_GRAPHICS_LIMIT_EXCEEDED;
     }
 
-    res = vkCreateImage(vk->device, &img_info, NULL, &s_priv->image);
+    res = vk->funcs.CreateImage(vk->device, &img_info, NULL, &s_priv->image);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "failed to create image: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -585,12 +586,12 @@ static int import_dma_buf(struct ngpu_texture *s)
         .sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR,
         .image = s_priv->image,
     };
-    vkGetImageMemoryRequirements2(vk->device, &mem_reqs_info, &mem_reqs);
+    vk->funcs.GetImageMemoryRequirements2(vk->device, &mem_reqs_info, &mem_reqs);
 
     VkMemoryFdPropertiesKHR fd_props = {
         .sType = VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,
     };
-    res = vk->GetMemoryFdPropertiesKHR(vk->device,
+    res = vk->funcs.GetMemoryFdPropertiesKHR(vk->device,
                                        VK_EXTERNAL_MEMORY_HANDLE_TYPE_DMA_BUF_BIT_EXT,
                                        dma_buf_params->fd,
                                        &fd_props);
@@ -626,7 +627,7 @@ static int import_dma_buf(struct ngpu_texture *s)
         mem_alloc_info.allocationSize = mem_reqs.memoryRequirements.size;
     }
 
-    res = vkAllocateMemory(vk->device, &mem_alloc_info, NULL, &s_priv->image_memory);
+    res = vk->funcs.AllocateMemory(vk->device, &mem_alloc_info, NULL, &s_priv->image_memory);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not allocate memory: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_MEMORY;
@@ -641,7 +642,7 @@ static int import_dma_buf(struct ngpu_texture *s)
      */
     s_priv->fd = -1;
 
-    res = vkBindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
+    res = vk->funcs.BindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not bind image memory: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -674,7 +675,7 @@ static int import_android_hardware_buffer(struct ngpu_texture *s)
         .pNext = &ahb_format_props,
     };
 
-    VkResult res = vk->GetAndroidHardwareBufferPropertiesANDROID(vk->device, hardware_buffer, &ahb_props);
+    VkResult res = vk->funcs.GetAndroidHardwareBufferPropertiesANDROID(vk->device, hardware_buffer, &ahb_props);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not get android hardware buffer properties: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -714,7 +715,7 @@ static int import_android_hardware_buffer(struct ngpu_texture *s)
         .sharingMode   = VK_SHARING_MODE_EXCLUSIVE,
     };
 
-    res = vkCreateImage(vk->device, &img_info, NULL, &s_priv->image);
+    res = vk->funcs.CreateImage(vk->device, &img_info, NULL, &s_priv->image);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not create image: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -745,13 +746,13 @@ static int import_android_hardware_buffer(struct ngpu_texture *s)
         .memoryTypeIndex = mem_type_index,
     };
 
-    res = vkAllocateMemory(vk->device, &mem_info, NULL, &s_priv->image_memory);
+    res = vk->funcs.AllocateMemory(vk->device, &mem_info, NULL, &s_priv->image_memory);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not allocate memory: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_MEMORY;
     }
 
-    res = vkBindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
+    res = vk->funcs.BindImageMemory(vk->device, s_priv->image, s_priv->image_memory, 0);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not bind image memory: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -783,7 +784,7 @@ static int import_android_hardware_buffer(struct ngpu_texture *s)
         .subresourceRange = subres_range,
     };
 
-    res = vkCreateImageView(vk->device, &view_info, NULL, &s_priv->image_view);
+    res = vk->funcs.CreateImageView(vk->device, &view_info, NULL, &s_priv->image_view);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not create image view: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -802,7 +803,7 @@ static int import_android_hardware_buffer(struct ngpu_texture *s)
     };
 
     VkCommandBuffer cmd_buf = gpu_ctx_vk->cur_cmd_buffer->cmd_buf;
-    vkCmdPipelineBarrier(cmd_buf,
+    vk->funcs.CmdPipelineBarrier(cmd_buf,
                          VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                          VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                          0,
@@ -849,7 +850,7 @@ static int import_metal_texture(struct ngpu_texture *s)
         .sharingMode = VK_SHARING_MODE_EXCLUSIVE,
     };
 
-    VkResult res = vkCreateImage(vk->device, &image_create_info, NULL, &s_priv->image);
+    VkResult res = vk->funcs.CreateImage(vk->device, &image_create_info, NULL, &s_priv->image);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not create image: %s", ngpu_vk_res2str(res));
         return ngpu_vk_res2ret(res);
@@ -959,7 +960,8 @@ void ngpu_texture_vk_transition_layout(struct ngpu_texture *s, VkImageLayout lay
         .baseArrayLayer = 0,
         .layerCount     = VK_REMAINING_ARRAY_LAYERS,
     };
-    transition_image_layout(cmd_buf, s_priv->image, s_priv->image_layout, layout, &subres_range);
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    transition_image_layout(&vk->funcs, cmd_buf, s_priv->image, s_priv->image_layout, layout, &subres_range);
 
     s_priv->image_layout = layout;
 }
@@ -992,8 +994,9 @@ void ngpu_texture_vk_copy_to_buffer(struct ngpu_texture *s, struct ngpu_buffer *
         .imageExtent = {s->params.width, s->params.height, 1},
     };
 
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
     VkCommandBuffer cmd_buf = gpu_ctx_vk->cur_cmd_buffer->cmd_buf;
-    vkCmdCopyImageToBuffer(cmd_buf, s_priv->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
+    vk->funcs.CmdCopyImageToBuffer(cmd_buf, s_priv->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                            buffer_vk->buffer, 1, &region);
 }
 
@@ -1097,7 +1100,8 @@ static VkResult texture_vk_upload(struct ngpu_texture *s, const uint8_t *data, c
         .baseArrayLayer = 0,
         .layerCount     = VK_REMAINING_ARRAY_LAYERS,
     };
-    transition_image_layout(cmd_buf,
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    transition_image_layout(&vk->funcs, cmd_buf,
                             s_priv->image,
                             s_priv->image_layout,
                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -1140,7 +1144,7 @@ static VkResult texture_vk_upload(struct ngpu_texture *s, const uint8_t *data, c
     }
 
     struct ngpu_buffer_vk *staging_buffer_vk = (struct ngpu_buffer_vk *)s_priv->staging_buffer;
-    vkCmdCopyBufferToImage(cmd_buf,
+    vk->funcs.CmdCopyBufferToImage(cmd_buf,
                            staging_buffer_vk->buffer,
                            s_priv->image,
                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -1149,7 +1153,7 @@ static VkResult texture_vk_upload(struct ngpu_texture *s, const uint8_t *data, c
 
     ngpu_darray_reset(&copy_regions);
 
-    transition_image_layout(cmd_buf,
+    transition_image_layout(&vk->funcs, cmd_buf,
                             s_priv->image,
                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                             s_priv->image_layout,
@@ -1218,7 +1222,8 @@ static VkResult texture_vk_generate_mipmap(struct ngpu_texture *s)
         .baseArrayLayer = 0,
         .layerCount     = VK_REMAINING_ARRAY_LAYERS,
     };
-    transition_image_layout(cmd_buf,
+    struct vkcontext *vk = gpu_ctx_vk->vkcontext;
+    transition_image_layout(&vk->funcs, cmd_buf,
                             s_priv->image,
                             s_priv->image_layout,
                             VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
@@ -1246,7 +1251,7 @@ static VkResult texture_vk_generate_mipmap(struct ngpu_texture *s)
         barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
         barrier.dstAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
 
-        vkCmdPipelineBarrier(cmd_buf,
+        vk->funcs.CmdPipelineBarrier(cmd_buf,
                              VK_PIPELINE_STAGE_TRANSFER_BIT,
                              VK_PIPELINE_STAGE_TRANSFER_BIT,
                              0,
@@ -1277,7 +1282,7 @@ static VkResult texture_vk_generate_mipmap(struct ngpu_texture *s)
             },
         };
 
-        vkCmdBlitImage(cmd_buf,
+        vk->funcs.CmdBlitImage(cmd_buf,
                        s_priv->image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                        s_priv->image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                        1, &blit,
@@ -1288,7 +1293,7 @@ static VkResult texture_vk_generate_mipmap(struct ngpu_texture *s)
         barrier.srcAccessMask = VK_ACCESS_TRANSFER_READ_BIT;
         barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
-        vkCmdPipelineBarrier(cmd_buf,
+        vk->funcs.CmdPipelineBarrier(cmd_buf,
                              VK_PIPELINE_STAGE_TRANSFER_BIT,
                              VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                              0,
@@ -1306,7 +1311,7 @@ static VkResult texture_vk_generate_mipmap(struct ngpu_texture *s)
     barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
 
-    vkCmdPipelineBarrier(cmd_buf,
+    vk->funcs.CmdPipelineBarrier(cmd_buf,
                          VK_PIPELINE_STAGE_TRANSFER_BIT,
                          VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                          0,
@@ -1343,12 +1348,12 @@ void ngpu_texture_vk_freep(struct ngpu_texture **sp)
 
     ngpu_ycbcr_sampler_vk_unrefp(&s_priv->ycbcr_sampler);
     if (!s_priv->wrapped_sampler)
-        vkDestroySampler(vk->device, s_priv->sampler, NULL);
+        vk->funcs.DestroySampler(vk->device, s_priv->sampler, NULL);
     if (!s_priv->wrapped_image_view)
-        vkDestroyImageView(vk->device, s_priv->image_view, NULL);
+        vk->funcs.DestroyImageView(vk->device, s_priv->image_view, NULL);
     if (!s_priv->wrapped_image)
-        vkDestroyImage(vk->device, s_priv->image, NULL);
-    vkFreeMemory(vk->device, s_priv->image_memory, NULL);
+        vk->funcs.DestroyImage(vk->device, s_priv->image, NULL);
+    vk->funcs.FreeMemory(vk->device, s_priv->image_memory, NULL);
 
     destroy_staging_buffer(s);
 

--- a/libngpu/src/vulkan/vkcontext.c
+++ b/libngpu/src/vulkan/vkcontext.c
@@ -35,9 +35,17 @@
 #endif
 
 #include <limits.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
-#include <vulkan/vulkan.h>
+
+#if !NGPU_VULKAN_STATIC
+# if defined(TARGET_WINDOWS)
+#  include <windows.h>
+# else
+#  include <dlfcn.h>
+# endif
+#endif
 
 #include "utils/log.h"
 #include "ctx.h"
@@ -112,13 +120,112 @@ static const char *platform_ext_names[] = {
     [NGPU_PLATFORM_WAYLAND] = "VK_KHR_wayland_surface",
 };
 
+#define NGPU_VK_FN_LOAD_INFO(req_inst, req_dev, optional, name) \
+    {"vk" #name, offsetof(struct vk_functions, name), req_inst, req_dev, optional},
+
+static const struct vk_function_load_info vk_load_infos[] = {
+    NGPU_VK_FN_LIST(NGPU_VK_FN_LOAD_INFO)
+    NGPU_VK_FN_LIST_ANDROID(NGPU_VK_FN_LOAD_INFO)
+};
+#undef NGPU_VK_FN_LOAD_INFO
+
+static VkResult load_functions(struct vkcontext *s, bool instance, bool device)
+{
+    struct vk_functions *funcs = &s->funcs;
+
+    for (size_t i = 0; i < NGPU_ARRAY_NB(vk_load_infos); i++) {
+        const struct vk_function_load_info *info = &vk_load_infos[i];
+        if (info->instance != instance || info->device != device)
+            continue;
+
+        PFN_vkVoidFunction func = NULL;
+        if (info->device)
+            func = funcs->GetDeviceProcAddr(s->device, info->name);
+        else if (info->instance)
+            func = funcs->GetInstanceProcAddr(s->instance, info->name);
+        else
+            func = funcs->GetInstanceProcAddr(NULL, info->name);
+
+        if (!func && !info->optional) {
+            LOG(ERROR, "could not load required Vulkan function: %s", info->name);
+            return VK_ERROR_INITIALIZATION_FAILED;
+        }
+
+        *(PFN_vkVoidFunction *)((uintptr_t)funcs + info->offset) = func;
+    }
+    return VK_SUCCESS;
+}
+
+#if NGPU_VULKAN_STATIC
+/*
+ * vkGetInstanceProcAddr is statically linked (e.g. via libvulkan or
+ * libMoltenVK on iOS/macOS). Forward-declare it since we build with
+ * VK_NO_PROTOTYPES.
+ */
+VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL vkGetInstanceProcAddr(VkInstance instance,
+                                                               const char *pName);
+
+static VkResult load_libvulkan(struct vkcontext *s)
+{
+    s->funcs.GetInstanceProcAddr = vkGetInstanceProcAddr;
+    return VK_SUCCESS;
+}
+#else
+static VkResult load_libvulkan(struct vkcontext *s)
+{
+    static const char *lib_names[] = {
+#if defined(TARGET_WINDOWS)
+        "vulkan-1.dll",
+#elif defined(TARGET_DARWIN)
+        "libvulkan.dylib",
+        "libvulkan.1.dylib",
+        "libMoltenVK.dylib",
+#elif defined(TARGET_IPHONE)
+        "libMoltenVK.dylib",
+#else
+        "libvulkan.so.1",
+        "libvulkan.so",
+#endif
+    };
+
+    for (size_t i = 0; i < NGPU_ARRAY_NB(lib_names); i++) {
+#if defined(TARGET_WINDOWS)
+        s->libvulkan = (void *)LoadLibraryA(lib_names[i]);
+#else
+        s->libvulkan = dlopen(lib_names[i], RTLD_NOW | RTLD_LOCAL);
+#endif
+        if (s->libvulkan)
+            break;
+    }
+
+    if (!s->libvulkan) {
+        LOG(ERROR, "could not load the Vulkan library");
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+#if defined(TARGET_WINDOWS)
+    s->funcs.GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)(void *)
+        GetProcAddress((HMODULE)s->libvulkan, "vkGetInstanceProcAddr");
+#else
+    s->funcs.GetInstanceProcAddr = (PFN_vkGetInstanceProcAddr)
+        dlsym(s->libvulkan, "vkGetInstanceProcAddr");
+#endif
+
+    if (!s->funcs.GetInstanceProcAddr) {
+        LOG(ERROR, "could not resolve vkGetInstanceProcAddr");
+        return VK_ERROR_INITIALIZATION_FAILED;
+    }
+
+    return VK_SUCCESS;
+}
+#endif
+
 static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type platform, int debug)
 {
     s->api_version = VK_API_VERSION_1_0;
 
-    VK_LOAD_FUNC(NULL, EnumerateInstanceVersion);
-    if (EnumerateInstanceVersion) {
-        VkResult res = EnumerateInstanceVersion(&s->api_version);
+    if (s->funcs.EnumerateInstanceVersion) {
+        VkResult res = s->funcs.EnumerateInstanceVersion(&s->api_version);
         if (res != VK_SUCCESS) {
             LOG(ERROR, "could not enumerate Vulkan instance version");
         }
@@ -140,7 +247,7 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
         return NGPU_ERROR_GRAPHICS_UNSUPPORTED;
     }
 
-    VkResult res = vkEnumerateInstanceLayerProperties(&s->nb_layers, NULL);
+    VkResult res = s->funcs.EnumerateInstanceLayerProperties(&s->nb_layers, NULL);
     if (res != VK_SUCCESS)
         return res;
 
@@ -148,7 +255,7 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
     if (!s->layers)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
 
-    res = vkEnumerateInstanceLayerProperties(&s->nb_layers, s->layers);
+    res = s->funcs.EnumerateInstanceLayerProperties(&s->nb_layers, s->layers);
     if (res != VK_SUCCESS)
         return res;
 
@@ -156,7 +263,7 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
     for (uint32_t i = 0; i < s->nb_layers; i++)
         LOG(DEBUG, "  %u/%u: %s", i+1, s->nb_layers, s->layers[i].layerName);
 
-    res = vkEnumerateInstanceExtensionProperties(NULL, &s->nb_extensions, NULL);
+    res = s->funcs.EnumerateInstanceExtensionProperties(NULL, &s->nb_extensions, NULL);
     if (res != VK_SUCCESS)
         return res;
 
@@ -164,7 +271,7 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
     if (!s->extensions)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
 
-    res = vkEnumerateInstanceExtensionProperties(NULL, &s->nb_extensions, s->extensions);
+    res = s->funcs.EnumerateInstanceExtensionProperties(NULL, &s->nb_extensions, s->extensions);
     if (res != VK_SUCCESS)
         return res;
 
@@ -241,14 +348,19 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
         .ppEnabledLayerNames     = ngpu_darray_data(&layers),
     };
 
-    res = vkCreateInstance(&instance_create_info, NULL, &s->instance);
+    res = s->funcs.CreateInstance(&instance_create_info, NULL, &s->instance);
+    if (res != VK_SUCCESS)
+        goto end;
+
+    res = load_functions(s, true, false);
     if (res != VK_SUCCESS)
         goto end;
 
     if (debug && has_debug_extension) {
-        VK_LOAD_FUNC(s->instance, CreateDebugUtilsMessengerEXT);
-        if (!CreateDebugUtilsMessengerEXT)
-            return VK_ERROR_EXTENSION_NOT_PRESENT;
+        if (!s->funcs.CreateDebugUtilsMessengerEXT) {
+            res = VK_ERROR_EXTENSION_NOT_PRESENT;
+            goto end;
+        }
 
         const VkDebugUtilsMessengerCreateInfoEXT info = {
             .sType           = VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
@@ -263,7 +375,7 @@ static VkResult create_instance(struct vkcontext *s, enum ngpu_platform_type pla
             .pUserData       = NULL,
         };
 
-        res = CreateDebugUtilsMessengerEXT(s->instance, &info, NULL, &s->debug_callback);
+        res = s->funcs.CreateDebugUtilsMessengerEXT(s->instance, &info, NULL, &s->debug_callback);
         if (res != VK_SUCCESS)
             goto end;
     }
@@ -302,7 +414,8 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
             .window = params->window,
         };
 
-        VK_LOAD_FUNC(s->instance, CreateXlibSurfaceKHR);
+        PFN_vkCreateXlibSurfaceKHR CreateXlibSurfaceKHR =
+            (PFN_vkCreateXlibSurfaceKHR)(void *)s->funcs.GetInstanceProcAddr(s->instance, "vkCreateXlibSurfaceKHR");
         if (!CreateXlibSurfaceKHR) {
             return VK_ERROR_EXTENSION_NOT_PRESENT;
         }
@@ -320,7 +433,8 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
             .window = (struct ANativeWindow *)params->window,
         };
 
-        VK_LOAD_FUNC(s->instance, CreateAndroidSurfaceKHR);
+        PFN_vkCreateAndroidSurfaceKHR CreateAndroidSurfaceKHR =
+            (PFN_vkCreateAndroidSurfaceKHR)(void *)s->funcs.GetInstanceProcAddr(s->instance, "vkCreateAndroidSurfaceKHR");
         if (!CreateAndroidSurfaceKHR) {
             return VK_ERROR_EXTENSION_NOT_PRESENT;
         }
@@ -343,7 +457,8 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
             .pLayer = layer,
         };
 
-        VK_LOAD_FUNC(s->instance, CreateMetalSurfaceEXT);
+        PFN_vkCreateMetalSurfaceEXT CreateMetalSurfaceEXT =
+            (PFN_vkCreateMetalSurfaceEXT)(void *)s->funcs.GetInstanceProcAddr(s->instance, "vkCreateMetalSurfaceEXT");
         if (!CreateMetalSurfaceEXT) {
             return VK_ERROR_EXTENSION_NOT_PRESENT;
         }
@@ -359,7 +474,8 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
             .hwnd = (HWND)params->window,
         };
 
-        VK_LOAD_FUNC(s->instance, CreateWin32SurfaceKHR);
+        PFN_vkCreateWin32SurfaceKHR CreateWin32SurfaceKHR =
+            (PFN_vkCreateWin32SurfaceKHR)(void *)s->funcs.GetInstanceProcAddr(s->instance, "vkCreateWin32SurfaceKHR");
         if (!CreateWin32SurfaceKHR) {
             return VK_ERROR_EXTENSION_NOT_PRESENT;
         }
@@ -376,7 +492,8 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
             .surface = (struct wl_surface *)params->window,
         };
 
-        VK_LOAD_FUNC(s->instance, CreateWaylandSurfaceKHR);
+        PFN_vkCreateWaylandSurfaceKHR CreateWaylandSurfaceKHR =
+            (PFN_vkCreateWaylandSurfaceKHR)(void *)s->funcs.GetInstanceProcAddr(s->instance, "vkCreateWaylandSurfaceKHR");
         if (!CreateWaylandSurfaceKHR) {
             return VK_ERROR_EXTENSION_NOT_PRESENT;
         }
@@ -396,7 +513,7 @@ static VkResult create_window_surface(struct vkcontext *s, const struct ngpu_ctx
 
 static VkResult enumerate_physical_devices(struct vkcontext *s, const struct ngpu_ctx_params *ctx_params)
 {
-    VkResult res = vkEnumeratePhysicalDevices(s->instance, &s->nb_phy_devices, NULL);
+    VkResult res = s->funcs.EnumeratePhysicalDevices(s->instance, &s->nb_phy_devices, NULL);
     if (res != VK_SUCCESS)
         return res;
 
@@ -407,7 +524,7 @@ static VkResult enumerate_physical_devices(struct vkcontext *s, const struct ngp
     if (!s->phy_devices)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
 
-    return vkEnumeratePhysicalDevices(s->instance, &s->nb_phy_devices, s->phy_devices);
+    return s->funcs.EnumeratePhysicalDevices(s->instance, &s->nb_phy_devices, s->phy_devices);
 }
 
 static void get_memory_property_flags_str(struct bstr *bstr, VkMemoryPropertyFlags flags)
@@ -454,13 +571,13 @@ static VkResult select_physical_device(struct vkcontext *s, const struct ngpu_ct
         VkPhysicalDevice phy_device = s->phy_devices[i];
 
         VkPhysicalDeviceProperties dev_props;
-        vkGetPhysicalDeviceProperties(phy_device, &dev_props);
+        s->funcs.GetPhysicalDeviceProperties(phy_device, &dev_props);
 
         VkPhysicalDeviceFeatures dev_features;
-        vkGetPhysicalDeviceFeatures(phy_device, &dev_features);
+        s->funcs.GetPhysicalDeviceFeatures(phy_device, &dev_features);
 
         VkPhysicalDeviceMemoryProperties mem_props;
-        vkGetPhysicalDeviceMemoryProperties(phy_device, &mem_props);
+        s->funcs.GetPhysicalDeviceMemoryProperties(phy_device, &mem_props);
 
         if (dev_props.deviceType >= NGPU_ARRAY_NB(types)) {
             LOG(ERROR, "device %s has unknown type: 0x%x, skipping", dev_props.deviceName, dev_props.deviceType);
@@ -468,11 +585,11 @@ static VkResult select_physical_device(struct vkcontext *s, const struct ngpu_ct
         }
 
         uint32_t qfamily_count = 0;
-        vkGetPhysicalDeviceQueueFamilyProperties(phy_device, &qfamily_count, NULL);
+        s->funcs.GetPhysicalDeviceQueueFamilyProperties(phy_device, &qfamily_count, NULL);
         VkQueueFamilyProperties *qfamily_props = ngpu_calloc(qfamily_count, sizeof(*qfamily_props));
         if (!qfamily_props)
             return VK_ERROR_OUT_OF_HOST_MEMORY;
-        vkGetPhysicalDeviceQueueFamilyProperties(phy_device, &qfamily_count, qfamily_props);
+        s->funcs.GetPhysicalDeviceQueueFamilyProperties(phy_device, &qfamily_count, qfamily_props);
 
         bool found_queues = false;
         uint32_t queue_family_graphics_id = UINT32_MAX;
@@ -484,7 +601,7 @@ static VkResult select_physical_device(struct vkcontext *s, const struct ngpu_ct
                 queue_family_graphics_id = j;
             if (s->surface) {
                 VkBool32 support;
-                vkGetPhysicalDeviceSurfaceSupportKHR(phy_device, j, s->surface, &support);
+                s->funcs.GetPhysicalDeviceSurfaceSupportKHR(phy_device, j, s->surface, &support);
                 if (support)
                     queue_family_present_id = j;
             }
@@ -539,7 +656,7 @@ static VkResult select_physical_device(struct vkcontext *s, const struct ngpu_ct
 
 static VkResult enumerate_extensions(struct vkcontext *s)
 {
-    VkResult res = vkEnumerateDeviceExtensionProperties(s->phy_device, NULL, &s->nb_device_extensions, NULL);
+    VkResult res = s->funcs.EnumerateDeviceExtensionProperties(s->phy_device, NULL, &s->nb_device_extensions, NULL);
     if (res != VK_SUCCESS)
         return res;
 
@@ -547,7 +664,7 @@ static VkResult enumerate_extensions(struct vkcontext *s)
     if (!s->device_extensions)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
 
-    res = vkEnumerateDeviceExtensionProperties(s->phy_device, NULL, &s->nb_device_extensions, s->device_extensions);
+    res = s->funcs.EnumerateDeviceExtensionProperties(s->phy_device, NULL, &s->nb_device_extensions, s->device_extensions);
     if (res != VK_SUCCESS)
         return res;
 
@@ -664,16 +781,20 @@ static VkResult create_device(struct vkcontext *s)
         .enabledExtensionCount   = (uint32_t)ngpu_darray_count(&enabled_extensions),
         .ppEnabledExtensionNames = ngpu_darray_data(&enabled_extensions),
     };
-    VkResult res = vkCreateDevice(s->phy_device, &device_create_info, NULL, &s->device);
+    VkResult res = s->funcs.CreateDevice(s->phy_device, &device_create_info, NULL, &s->device);
 
     ngpu_darray_reset(&enabled_extensions);
 
     if (res != VK_SUCCESS)
         return res;
 
-    vkGetDeviceQueue(s->device, s->graphics_queue_index, 0, &s->graphic_queue);
+    res = load_functions(s, true, true);
+    if (res != VK_SUCCESS)
+        return res;
+
+    s->funcs.GetDeviceQueue(s->device, s->graphics_queue_index, 0, &s->graphic_queue);
     if (s->present_queue_index != -1)
-        vkGetDeviceQueue(s->device, s->present_queue_index, 0, &s->present_queue);
+        s->funcs.GetDeviceQueue(s->device, s->present_queue_index, 0, &s->present_queue);
 
     return VK_SUCCESS;
 }
@@ -684,7 +805,7 @@ VkFormat ngpu_vkcontext_find_supported_format(struct vkcontext *s, const VkForma
     uint32_t i = 0;
     while (formats[i]) {
         VkFormatProperties properties;
-        vkGetPhysicalDeviceFormatProperties(s->phy_device, formats[i], &properties);
+        s->funcs.GetPhysicalDeviceFormatProperties(s->phy_device, formats[i], &properties);
         if (tiling == VK_IMAGE_TILING_LINEAR &&
             NGPU_HAS_ALL_FLAGS(properties.linearTilingFeatures, features))
             return formats[i];
@@ -709,25 +830,25 @@ static VkResult query_swapchain_support(struct vkcontext *s)
     if (!s->surface)
         return VK_SUCCESS;
 
-    vkGetPhysicalDeviceSurfaceCapabilitiesKHR(s->phy_device, s->surface, &s->surface_caps);
+    s->funcs.GetPhysicalDeviceSurfaceCapabilitiesKHR(s->phy_device, s->surface, &s->surface_caps);
 
-    vkGetPhysicalDeviceSurfaceFormatsKHR(s->phy_device, s->surface, &s->nb_surface_formats, NULL);
+    s->funcs.GetPhysicalDeviceSurfaceFormatsKHR(s->phy_device, s->surface, &s->nb_surface_formats, NULL);
     if (!s->nb_surface_formats)
         return VK_ERROR_FORMAT_NOT_SUPPORTED;
 
     s->surface_formats = ngpu_calloc(s->nb_surface_formats, sizeof(*s->surface_formats));
     if (!s->surface_formats)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
-    vkGetPhysicalDeviceSurfaceFormatsKHR(s->phy_device, s->surface, &s->nb_surface_formats, s->surface_formats);
+    s->funcs.GetPhysicalDeviceSurfaceFormatsKHR(s->phy_device, s->surface, &s->nb_surface_formats, s->surface_formats);
 
-    vkGetPhysicalDeviceSurfacePresentModesKHR(s->phy_device, s->surface, &s->nb_present_modes, NULL);
+    s->funcs.GetPhysicalDeviceSurfacePresentModesKHR(s->phy_device, s->surface, &s->nb_present_modes, NULL);
     if (!s->nb_present_modes)
         return VK_ERROR_FORMAT_NOT_SUPPORTED;
 
     s->present_modes = ngpu_calloc(s->nb_present_modes, sizeof(*s->present_modes));
     if (!s->present_modes)
         return VK_ERROR_OUT_OF_HOST_MEMORY;
-    vkGetPhysicalDeviceSurfacePresentModesKHR(s->phy_device, s->surface, &s->nb_present_modes, s->present_modes);
+    s->funcs.GetPhysicalDeviceSurfacePresentModesKHR(s->phy_device, s->surface, &s->nb_present_modes, s->present_modes);
 
     return VK_SUCCESS;
 }
@@ -782,45 +903,45 @@ static VkResult select_preferred_formats(struct vkcontext *s)
     return VK_SUCCESS;
 }
 
-struct vk_function {
+struct vk_ext_function {
     const char *name;
     size_t offset;
     int device;
 };
 
-#define DECLARE_FUNC(n, d) {                 \
-    .name = "vk" #n,                         \
-    .offset = offsetof(struct vkcontext, n), \
-    .device = d,                             \
-}                                            \
+#define DECLARE_EXT_FUNC(n, d) {                         \
+    .name = "vk" #n,                                     \
+    .offset = offsetof(struct vk_functions, n),          \
+    .device = d,                                         \
+}                                                        \
 
 struct vk_extension {
     const char *name;
     int device;
-    const struct vk_function *functions;
+    const struct vk_ext_function *functions;
 } vk_extensions[] = {
     {
         .name = VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME,
         .device = 1,
-        .functions = (const struct vk_function[]) {
-            DECLARE_FUNC(GetMemoryFdKHR, 1),
-            DECLARE_FUNC(GetMemoryFdPropertiesKHR, 1),
+        .functions = (const struct vk_ext_function[]) {
+            DECLARE_EXT_FUNC(GetMemoryFdKHR, 1),
+            DECLARE_EXT_FUNC(GetMemoryFdPropertiesKHR, 1),
             {0},
         },
     }, {
         .name = VK_GOOGLE_DISPLAY_TIMING_EXTENSION_NAME,
         .device = 1,
-        .functions = (const struct vk_function[]) {
-            DECLARE_FUNC(GetRefreshCycleDurationGOOGLE, 1),
-            DECLARE_FUNC(GetPastPresentationTimingGOOGLE, 1),
+        .functions = (const struct vk_ext_function[]) {
+            DECLARE_EXT_FUNC(GetRefreshCycleDurationGOOGLE, 1),
+            DECLARE_EXT_FUNC(GetPastPresentationTimingGOOGLE, 1),
             {0},
         },
     }, {
         .name = VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME,
         .device = 1,
-        .functions = (const struct vk_function[]) {
-            DECLARE_FUNC(CreateSamplerYcbcrConversionKHR, 1),
-            DECLARE_FUNC(DestroySamplerYcbcrConversionKHR, 1),
+        .functions = (const struct vk_ext_function[]) {
+            DECLARE_EXT_FUNC(CreateSamplerYcbcrConversionKHR, 1),
+            DECLARE_EXT_FUNC(DestroySamplerYcbcrConversionKHR, 1),
             {0},
         },
     },
@@ -828,22 +949,22 @@ struct vk_extension {
     {
         .name = VK_ANDROID_EXTERNAL_MEMORY_ANDROID_HARDWARE_BUFFER_EXTENSION_NAME,
         .device = 1,
-        .functions = (const struct vk_function[]) {
-            DECLARE_FUNC(GetAndroidHardwareBufferPropertiesANDROID, 1),
-            DECLARE_FUNC(GetMemoryAndroidHardwareBufferANDROID, 1),
+        .functions = (const struct vk_ext_function[]) {
+            DECLARE_EXT_FUNC(GetAndroidHardwareBufferPropertiesANDROID, 1),
+            DECLARE_EXT_FUNC(GetMemoryAndroidHardwareBufferANDROID, 1),
             {0},
         },
     },
 #endif
 };
 
-static int load_function(struct vkcontext *s, const struct vk_function *func)
+static int load_ext_function(struct vkcontext *s, const struct vk_ext_function *func)
 {
-    PFN_vkVoidFunction *func_ptr = (void *)((uintptr_t)s + func->offset);
+    PFN_vkVoidFunction *func_ptr = (void *)((uintptr_t)&s->funcs + func->offset);
     if (func->device)
-        *func_ptr = vkGetDeviceProcAddr(s->device, func->name);
+        *func_ptr = s->funcs.GetDeviceProcAddr(s->device, func->name);
     else
-        *func_ptr = vkGetInstanceProcAddr(s->instance, func->name);
+        *func_ptr = s->funcs.GetInstanceProcAddr(s->instance, func->name);
 
     if (!*func_ptr)
         return 0;
@@ -851,14 +972,14 @@ static int load_function(struct vkcontext *s, const struct vk_function *func)
     return 1;
 }
 
-static VkResult load_functions(struct vkcontext *s)
+static VkResult load_ext_functions(struct vkcontext *s)
 {
     for (size_t i = 0; i < NGPU_ARRAY_NB(vk_extensions); i++) {
         struct vk_extension *ext = &vk_extensions[i];
         if (!ngpu_vkcontext_has_extension(s, ext->name, ext->device))
             continue;
-        for (const struct vk_function *func = ext->functions; func && func->name; func++) {
-            if (!load_function(s, func)) {
+        for (const struct vk_ext_function *func = ext->functions; func && func->name; func++) {
+            if (!load_ext_function(s, func)) {
                 LOG(ERROR, "could not load %s() required by extension %s",
                     func->name, ext->name);
                 return VK_ERROR_EXTENSION_NOT_PRESENT;
@@ -876,7 +997,17 @@ struct vkcontext *ngpu_vkcontext_create(void)
 
 VkResult ngpu_vkcontext_init(struct vkcontext *s, const struct ngpu_ctx_params *params)
 {
-    VkResult res = create_instance(s, params->platform, params->debug);
+    VkResult res = load_libvulkan(s);
+    if (res != VK_SUCCESS)
+        return res;
+
+    res = load_functions(s, false, false);
+    if (res != VK_SUCCESS) {
+        LOG(ERROR, "failed to load global Vulkan functions");
+        return res;
+    }
+
+    res = create_instance(s, params->platform, params->debug);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "failed to create instance: %s", ngpu_vk_res2str(res));
         return res;
@@ -904,7 +1035,7 @@ VkResult ngpu_vkcontext_init(struct vkcontext *s, const struct ngpu_ctx_params *
     if (res != VK_SUCCESS)
         return res;
 
-    res = load_functions(s);
+    res = load_ext_functions(s);
     if (res != VK_SUCCESS)
         return res;
 
@@ -921,7 +1052,7 @@ VkResult ngpu_vkcontext_init(struct vkcontext *s, const struct ngpu_ctx_params *
 
 void *ngpu_vkcontext_get_proc_addr(struct vkcontext *s, const char *name)
 {
-    return vkGetInstanceProcAddr(s->instance, name);
+    return (void *)s->funcs.GetInstanceProcAddr(s->instance, name);
 }
 
 int ngpu_vkcontext_has_extension(const struct vkcontext *s, const char *name, int device)
@@ -951,18 +1082,15 @@ void ngpu_vkcontext_freep(struct vkcontext **sp)
         return;
 
     if (s->device) {
-        vkDeviceWaitIdle(s->device);
-        vkDestroyDevice(s->device, NULL);
+        s->funcs.DeviceWaitIdle(s->device);
+        s->funcs.DestroyDevice(s->device, NULL);
     }
 
-    if (s->surface)
-        vkDestroySurfaceKHR(s->instance, s->surface, NULL);
+    if (s->surface && s->funcs.DestroySurfaceKHR)
+        s->funcs.DestroySurfaceKHR(s->instance, s->surface, NULL);
 
-    if (s->debug_callback) {
-        VK_LOAD_FUNC(s->instance, DestroyDebugUtilsMessengerEXT);
-        if (DestroyDebugUtilsMessengerEXT)
-            DestroyDebugUtilsMessengerEXT(s->instance, s->debug_callback, NULL);
-    }
+    if (s->debug_callback && s->funcs.DestroyDebugUtilsMessengerEXT)
+        s->funcs.DestroyDebugUtilsMessengerEXT(s->instance, s->debug_callback, NULL);
 
     ngpu_freep(&s->present_modes);
     ngpu_freep(&s->surface_formats);
@@ -971,11 +1099,22 @@ void ngpu_vkcontext_freep(struct vkcontext **sp)
     ngpu_freep(&s->layers);
     ngpu_freep(&s->extensions);
 
-    vkDestroyInstance(s->instance, NULL);
+    if (s->funcs.DestroyInstance)
+        s->funcs.DestroyInstance(s->instance, NULL);
 
 #if defined(TARGET_LINUX)
     if (s->own_x11_display)
         XCloseDisplay(s->x11_display);
+#endif
+
+#if !NGPU_VULKAN_STATIC
+    if (s->libvulkan) {
+# if defined(TARGET_WINDOWS)
+        FreeLibrary((HMODULE)s->libvulkan);
+# else
+        dlclose(s->libvulkan);
+# endif
+    }
 #endif
 
     ngpu_freep(sp);

--- a/libngpu/src/vulkan/vkcontext.h
+++ b/libngpu/src/vulkan/vkcontext.h
@@ -28,12 +28,7 @@
 
 #include "ctx.h"
 #include "ngpu/ngpu.h"
-
-#define VK_FUNC(name) PFN_vk##name
-#define VK_DECLARE_FUNC(name) VK_FUNC(name) name
-
-#define VK_LOAD_FUNC(instance, name) \
-    VK_DECLARE_FUNC(name) = (VK_FUNC(name))(void *)vkGetInstanceProcAddr(instance, "vk" #name);
+#include "vulkan/vkfunctions.h"
 
 struct vkcontext {
     uint32_t api_version;
@@ -76,17 +71,10 @@ struct vkcontext {
     VkPresentModeKHR *present_modes;
     uint32_t nb_present_modes;
 
-    /* Device functions */
-    VK_DECLARE_FUNC(CreateSamplerYcbcrConversionKHR);
-    VK_DECLARE_FUNC(DestroySamplerYcbcrConversionKHR);
-#if defined(TARGET_ANDROID)
-    VK_DECLARE_FUNC(GetAndroidHardwareBufferPropertiesANDROID);
-    VK_DECLARE_FUNC(GetMemoryAndroidHardwareBufferANDROID);
+    struct vk_functions funcs;
+#if !NGPU_VULKAN_STATIC
+    void *libvulkan;
 #endif
-    VK_DECLARE_FUNC(GetMemoryFdKHR);
-    VK_DECLARE_FUNC(GetMemoryFdPropertiesKHR);
-    VK_DECLARE_FUNC(GetRefreshCycleDurationGOOGLE);
-    VK_DECLARE_FUNC(GetPastPresentationTimingGOOGLE);
 };
 
 struct vkcontext *ngpu_vkcontext_create(void);

--- a/libngpu/src/vulkan/vkfunctions.h
+++ b/libngpu/src/vulkan/vkfunctions.h
@@ -1,0 +1,176 @@
+/*
+ * Copyright 2026 Matthieu Bouron <matthieu.bouron@gmail.com>
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef VKFUNCTIONS_H
+#define VKFUNCTIONS_H
+
+#include "config.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <vulkan/vulkan.h>
+
+#define NGPU_VK_FN_LIST(MACRO)                                               \
+    /* Pre-instance globals */                                               \
+    MACRO(false, false, false, GetInstanceProcAddr)                          \
+    MACRO(false, false, true, EnumerateInstanceVersion)                      \
+    MACRO(false, false, false, EnumerateInstanceLayerProperties)             \
+    MACRO(false, false, false, EnumerateInstanceExtensionProperties)         \
+    MACRO(false, false, false, CreateInstance)                               \
+                                                                             \
+    /* Instance-level */                                                     \
+    MACRO(true, false, false, DestroyInstance)                               \
+    MACRO(true, false, false, EnumeratePhysicalDevices)                      \
+    MACRO(true, false, false, GetPhysicalDeviceProperties)                   \
+    MACRO(true, false, false, GetPhysicalDeviceFeatures)                     \
+    MACRO(true, false, false, GetPhysicalDeviceMemoryProperties)             \
+    MACRO(true, false, false, GetPhysicalDeviceQueueFamilyProperties)        \
+    MACRO(true, false, false, GetPhysicalDeviceFormatProperties)             \
+    MACRO(true, false, true, GetPhysicalDeviceImageFormatProperties2)        \
+    MACRO(true, false, true, GetPhysicalDeviceSurfaceSupportKHR)             \
+    MACRO(true, false, true, GetPhysicalDeviceSurfaceCapabilitiesKHR)        \
+    MACRO(true, false, true, GetPhysicalDeviceSurfaceFormatsKHR)             \
+    MACRO(true, false, true, GetPhysicalDeviceSurfacePresentModesKHR)        \
+    MACRO(true, false, false, EnumerateDeviceExtensionProperties)            \
+    MACRO(true, false, false, CreateDevice)                                  \
+    MACRO(true, false, false, GetDeviceProcAddr)                             \
+    MACRO(true, false, true, DestroySurfaceKHR)                              \
+    MACRO(true, false, true, CreateDebugUtilsMessengerEXT)                   \
+    MACRO(true, false, true, DestroyDebugUtilsMessengerEXT)                  \
+                                                                             \
+    /* Device-level */                                                       \
+    MACRO(true, true, false, DestroyDevice)                                  \
+    MACRO(true, true, false, DeviceWaitIdle)                                 \
+    MACRO(true, true, false, GetDeviceQueue)                                 \
+    MACRO(true, true, false, QueueSubmit)                                    \
+    MACRO(true, true, true, QueuePresentKHR)                                 \
+    MACRO(true, true, false, CreateCommandPool)                              \
+    MACRO(true, true, false, DestroyCommandPool)                             \
+    MACRO(true, true, false, AllocateCommandBuffers)                         \
+    MACRO(true, true, false, FreeCommandBuffers)                             \
+    MACRO(true, true, false, BeginCommandBuffer)                             \
+    MACRO(true, true, false, EndCommandBuffer)                               \
+    MACRO(true, true, false, ResetCommandBuffer)                             \
+    MACRO(true, true, false, CreateFence)                                    \
+    MACRO(true, true, false, DestroyFence)                                   \
+    MACRO(true, true, false, WaitForFences)                                  \
+    MACRO(true, true, false, ResetFences)                                    \
+    MACRO(true, true, false, GetFenceStatus)                                 \
+    MACRO(true, true, false, CreateSemaphore)                                \
+    MACRO(true, true, false, DestroySemaphore)                               \
+    MACRO(true, true, false, CreateBuffer)                                   \
+    MACRO(true, true, false, DestroyBuffer)                                  \
+    MACRO(true, true, false, GetBufferMemoryRequirements)                    \
+    MACRO(true, true, false, AllocateMemory)                                 \
+    MACRO(true, true, false, FreeMemory)                                     \
+    MACRO(true, true, false, BindBufferMemory)                               \
+    MACRO(true, true, false, MapMemory)                                      \
+    MACRO(true, true, false, UnmapMemory)                                    \
+    MACRO(true, true, false, CreateImage)                                    \
+    MACRO(true, true, false, DestroyImage)                                   \
+    MACRO(true, true, false, GetImageMemoryRequirements)                     \
+    MACRO(true, true, true, GetImageMemoryRequirements2)                     \
+    MACRO(true, true, false, BindImageMemory)                                \
+    MACRO(true, true, false, CreateImageView)                                \
+    MACRO(true, true, false, DestroyImageView)                               \
+    MACRO(true, true, false, CreateSampler)                                  \
+    MACRO(true, true, false, DestroySampler)                                 \
+    MACRO(true, true, false, CreateRenderPass)                               \
+    MACRO(true, true, false, DestroyRenderPass)                              \
+    MACRO(true, true, false, CreateFramebuffer)                              \
+    MACRO(true, true, false, DestroyFramebuffer)                             \
+    MACRO(true, true, false, CreateShaderModule)                             \
+    MACRO(true, true, false, DestroyShaderModule)                            \
+    MACRO(true, true, false, CreatePipelineLayout)                           \
+    MACRO(true, true, false, DestroyPipelineLayout)                          \
+    MACRO(true, true, false, CreateGraphicsPipelines)                        \
+    MACRO(true, true, false, CreateComputePipelines)                         \
+    MACRO(true, true, false, DestroyPipeline)                                \
+    MACRO(true, true, false, CreateDescriptorSetLayout)                      \
+    MACRO(true, true, false, DestroyDescriptorSetLayout)                     \
+    MACRO(true, true, false, CreateDescriptorPool)                           \
+    MACRO(true, true, false, DestroyDescriptorPool)                          \
+    MACRO(true, true, false, ResetDescriptorPool)                            \
+    MACRO(true, true, false, AllocateDescriptorSets)                         \
+    MACRO(true, true, false, UpdateDescriptorSets)                           \
+    MACRO(true, true, false, CreateQueryPool)                                \
+    MACRO(true, true, false, DestroyQueryPool)                               \
+    MACRO(true, true, false, GetQueryPoolResults)                            \
+    MACRO(true, true, true, CreateSwapchainKHR)                              \
+    MACRO(true, true, true, DestroySwapchainKHR)                             \
+    MACRO(true, true, true, GetSwapchainImagesKHR)                           \
+    MACRO(true, true, true, AcquireNextImageKHR)                             \
+                                                                             \
+    /* Device-level command buffer recording */                              \
+    MACRO(true, true, false, CmdBeginRenderPass)                             \
+    MACRO(true, true, false, CmdEndRenderPass)                               \
+    MACRO(true, true, false, CmdBindPipeline)                                \
+    MACRO(true, true, false, CmdBindDescriptorSets)                          \
+    MACRO(true, true, false, CmdBindVertexBuffers)                           \
+    MACRO(true, true, false, CmdBindIndexBuffer)                             \
+    MACRO(true, true, false, CmdDraw)                                        \
+    MACRO(true, true, false, CmdDrawIndexed)                                 \
+    MACRO(true, true, false, CmdDispatch)                                    \
+    MACRO(true, true, false, CmdCopyBuffer)                                  \
+    MACRO(true, true, false, CmdCopyBufferToImage)                           \
+    MACRO(true, true, false, CmdCopyImageToBuffer)                           \
+    MACRO(true, true, false, CmdBlitImage)                                   \
+    MACRO(true, true, false, CmdPipelineBarrier)                             \
+    MACRO(true, true, false, CmdSetViewport)                                 \
+    MACRO(true, true, false, CmdSetScissor)                                  \
+    MACRO(true, true, false, CmdSetLineWidth)                                \
+    MACRO(true, true, false, CmdResetQueryPool)                              \
+    MACRO(true, true, false, CmdWriteTimestamp)                              \
+                                                                             \
+    /* Device-level extension functions */                                   \
+    MACRO(true, true, true, CreateSamplerYcbcrConversionKHR)                 \
+    MACRO(true, true, true, DestroySamplerYcbcrConversionKHR)                \
+    MACRO(true, true, true, GetMemoryFdKHR)                                  \
+    MACRO(true, true, true, GetMemoryFdPropertiesKHR)                        \
+    MACRO(true, true, true, GetRefreshCycleDurationGOOGLE)                   \
+    MACRO(true, true, true, GetPastPresentationTimingGOOGLE)
+
+#if defined(TARGET_ANDROID)
+#define NGPU_VK_FN_LIST_ANDROID(MACRO)                                       \
+    MACRO(true, true, true, GetAndroidHardwareBufferPropertiesANDROID)       \
+    MACRO(true, true, true, GetMemoryAndroidHardwareBufferANDROID)
+#else
+#define NGPU_VK_FN_LIST_ANDROID(MACRO)
+#endif
+
+#define NGPU_VK_FN_DEF(req_inst, req_dev, optional, name) PFN_vk##name name;
+
+struct vk_functions {
+    NGPU_VK_FN_LIST(NGPU_VK_FN_DEF)
+    NGPU_VK_FN_LIST_ANDROID(NGPU_VK_FN_DEF)
+};
+
+#undef NGPU_VK_FN_DEF
+
+struct vk_function_load_info {
+    const char *name;
+    size_t offset;
+    bool instance;
+    bool device;
+    bool optional;
+};
+
+#endif /* VKFUNCTIONS_H */

--- a/libngpu/src/vulkan/ycbcr_sampler_vk.c
+++ b/libngpu/src/vulkan/ycbcr_sampler_vk.c
@@ -51,7 +51,7 @@ int ngpu_ycbcr_sampler_vk_params_from_ahb(struct ngpu_ctx *gpu_ctx, struct AHard
     };
 
     VkResult res =
-        vk->GetAndroidHardwareBufferPropertiesANDROID(vk->device, ahb, &ahb_props);
+        vk->funcs.GetAndroidHardwareBufferPropertiesANDROID(vk->device, ahb, &ahb_props);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not get android hardware buffer properties: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -92,8 +92,8 @@ static void ycbcr_sampler_freep(void **texturep)
     struct ngpu_ctx *gpu_ctx = s->gpu_ctx;
     struct ngpu_ctx_vk *gpu_ctx_vk = (struct ngpu_ctx_vk *)gpu_ctx;
     struct vkcontext *vk = gpu_ctx_vk->vkcontext;
-    vkDestroySampler(vk->device, s->sampler, NULL);
-    vk->DestroySamplerYcbcrConversionKHR(vk->device, s->conv, NULL);
+    vk->funcs.DestroySampler(vk->device, s->sampler, NULL);
+    vk->funcs.DestroySamplerYcbcrConversionKHR(vk->device, s->conv, NULL);
 
     ngpu_freep(sp);
 }
@@ -134,7 +134,7 @@ VkResult ngpu_ycbcr_sampler_vk_init(struct ngpu_ycbcr_sampler_vk *s, const struc
         .forceExplicitReconstruction = VK_FALSE,
     };
 
-    VkResult res = vk->CreateSamplerYcbcrConversionKHR(vk->device, &sampler_ycbcr_info, 0, &s->conv);
+    VkResult res = vk->funcs.CreateSamplerYcbcrConversionKHR(vk->device, &sampler_ycbcr_info, 0, &s->conv);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not create sampler YCbCr conversion: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;
@@ -165,7 +165,7 @@ VkResult ngpu_ycbcr_sampler_vk_init(struct ngpu_ycbcr_sampler_vk *s, const struc
         .unnormalizedCoordinates = VK_FALSE,
     };
 
-    res = vkCreateSampler(vk->device, &sampler_info, 0, &s->sampler);
+    res = vk->funcs.CreateSampler(vk->device, &sampler_info, 0, &s->sampler);
     if (res != VK_SUCCESS) {
         LOG(ERROR, "could not create sampler: %s", ngpu_vk_res2str(res));
         return NGPU_ERROR_GRAPHICS_GENERIC;


### PR DESCRIPTION
Vulkan is now loaded at runtime through dlopen instead of being linked at build time. The library only needs the Vulkan headers.

This is a standard Vulkan integration pattern (used by FFmpeg, SDL, ...). It allows the library to be built and shipped on systems without a Vulkan loader present, with the backend simply disabled at runtime if the loader is missing.