### PR TITLE
ngl-tools/viewer: drive scene rendering from the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](https://semver.org/spec/v2.0.0.html) for `libnopegl`.
 ### Fixed
 - `Effect2D` rendertarget size potentially exceeding the GPU max 2D texture
   dimension when children extend far off-canvas
+- `ngl-viewer` scene playback stutter
 
 ## [2026.1 / libnopegl 0.13.0][2026.1] - 2026-05-21
 ### Added

--- a/ngl-tools/ngl-viewer.c
+++ b/ngl-tools/ngl-viewer.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
         .panel_ratio           = VIEWER_PANEL_RATIO_MIN,
         .framerate             = {60, 1},
         .selected_scene        = -1,
-        .clock_off             = -1,
+        .clock_off_ns          = -1,
         .export_height         = 720,
     };
 
@@ -224,6 +224,7 @@ int main(int argc, char *argv[])
     Uint64 last_mtime_check = SDL_GetTicks();
     Uint64 last_hooks_refresh = SDL_GetTicks() - 3000; /* Fire on first iter. */
     uint32_t last_resize_w = 0, last_resize_h = 0;
+    double last_render_t = -1.0;
     while (run) {
         /* Nuklear's event handling. */
         nk_input_begin(nk);
@@ -238,7 +239,8 @@ int main(int argc, char *argv[])
                         s.duration     = r->duration;
                         s.framerate[0] = r->framerate[0];
                         s.framerate[1] = r->framerate[1];
-                        s.clock_off    = -1;
+                        s.clock_off_ns = -1;
+                        last_render_t  = -1.0;
                         viewer_set_frame_time(&s, 0.0);
                         s.paused       = 0;
                         s.last_error[0] = '\0';
@@ -291,21 +293,21 @@ int main(int argc, char *argv[])
                 if (event.key.key == SDLK_SPACE) {
                     s.paused ^= 1;
                     if (!s.paused)
-                        s.clock_off = (int64_t)SDL_GetTicks() - (int64_t)(s.frame_time * 1000.0);
+                        s.clock_off_ns = (int64_t)viewer_now_ns(&s) - (int64_t)(viewer_get_frame_time(&s) * 1.0e9);
                     continue;
                 }
                 /* LEFT/RIGHT: ±1 second seek. */
                 if ((event.key.key == SDLK_LEFT || event.key.key == SDLK_RIGHT) &&
                     s.scene_loaded) {
                     const double seek_step = 1.0;
-                    double t = s.frame_time;
+                    double t = viewer_get_frame_time(&s);
                     t += (event.key.key == SDLK_LEFT) ? -seek_step : seek_step;
                     if (t < 0.0)
                         t = 0.0;
                     else if (t > s.duration)
                         t = s.duration;
                     viewer_set_frame_time(&s, t);
-                    s.clock_off = (int64_t)SDL_GetTicks() - (int64_t)(t * 1000.0);
+                    s.clock_off_ns = (int64_t)viewer_now_ns(&s) - (int64_t)(t * 1.0e9);
                     continue;
                 }
                 /* O/P: ±1 frame step. */
@@ -313,7 +315,7 @@ int main(int argc, char *argv[])
                     s.scene_loaded && s.framerate[0]) {
                     s.paused = 1;
                     const double step = (double)s.framerate[1] / (double)s.framerate[0];
-                    double t = s.frame_time;
+                    double t = viewer_get_frame_time(&s);
                     t += (event.key.key == SDLK_O) ? -step : step;
                     if (t < 0.0)
                         t = 0.0;
@@ -361,6 +363,20 @@ int main(int argc, char *argv[])
                     .type   = SCENE_CMD_RESIZE,
                     .resize = {.width = new_w, .height = new_h},
                 });
+            }
+        }
+
+        /* Drive the scene from the UI: post one render request per UI
+         * iteration with the predicted-vsync-aligned target time. Posted after
+         * RESIZE so the resize is processed first if both are queued. */
+        if (s.scene_loaded) {
+            const double t = viewer_get_frame_time(&s);
+            if (t != last_render_t) {
+                scene_cmd_post(&s.cmd_q, (struct scene_cmd){
+                    .type   = SCENE_CMD_RENDER,
+                    .render = {.target_time = t},
+                });
+                last_render_t = t;
             }
         }
 

--- a/ngl-tools/viewer.h
+++ b/ngl-tools/viewer.h
@@ -122,14 +122,29 @@ struct viewer_ctx {
     double  duration;
     int32_t framerate[2];
 
-    int64_t clock_off;
+    int64_t clock_off_ns;
     int paused;
 
     /*
-     * Playback time in seconds. Shared between the scene and main threads.
-     * Must be accessed through viewer_{get,set}_frame_time().
+     * Vsync clock (approximation).
+     *
+     * `last_swap_ns` is the SDL_GetTicksNS() snapshot captured right after the
+     * most recent present returned; since the GPU swap blocks on vsync, this
+     * is an approximation of the vsync instant.
+     *
+     * `refresh_period_ns` is one display refresh in ns, sampled from
+     * the current display mode at compositor init.
+     *
+     * viewer_now_ns() uses `last_swap_ns` + `refresh_period_ns` as the
+     * predicted timestamp of the vsync this UI iteration will land on — that's
+     * the time we hand to the scene so its animation matches what gets shown.
      */
-    SDL_Mutex *frame_time_lock;
+    Uint64 last_swap_ns;
+    Uint64 refresh_period_ns;
+
+    /*
+     * Playback time in seconds.
+     */
     double frame_time;
 
     /*
@@ -182,17 +197,24 @@ static inline float viewer_ui_scale(const struct viewer_ctx *s)
 
 static inline double viewer_get_frame_time(struct viewer_ctx *s)
 {
-    SDL_LockMutex(s->frame_time_lock);
-    const double t = s->frame_time;
-    SDL_UnlockMutex(s->frame_time_lock);
-    return t;
+    return s->frame_time;
 }
 
 static inline void viewer_set_frame_time(struct viewer_ctx *s, double t)
 {
-    SDL_LockMutex(s->frame_time_lock);
     s->frame_time = t;
-    SDL_UnlockMutex(s->frame_time_lock);
+}
+
+/*
+ * Return a ns timestamp aligned with the next vsync this UI iteration is
+ * predicted to land on. Falls back to SDL_GetTicksNS() before the first
+ * present, when last_swap_ns is still zero.
+ */
+static inline Uint64 viewer_now_ns(const struct viewer_ctx *s)
+{
+    if (!s->last_swap_ns || !s->refresh_period_ns)
+        return SDL_GetTicksNS();
+    return s->last_swap_ns + s->refresh_period_ns;
 }
 
 #endif

--- a/ngl-tools/viewer_compositor.c
+++ b/ngl-tools/viewer_compositor.c
@@ -77,6 +77,17 @@ int viewer_compositor_init(struct viewer_ctx *s,
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to initialize blit");
         return -1;
     }
+
+    const SDL_DisplayID display = SDL_GetDisplayForWindow(s->window);
+    const SDL_DisplayMode *mode = display ? SDL_GetCurrentDisplayMode(display) : NULL;
+    if (mode && mode->refresh_rate_numerator > 0 && mode->refresh_rate_denominator > 0) {
+        s->refresh_period_ns =
+            SDL_NS_PER_SECOND * (Uint64)mode->refresh_rate_denominator /
+            (Uint64)mode->refresh_rate_numerator;
+    } else {
+        s->refresh_period_ns = SDL_NS_PER_SECOND / 60;
+    }
+
     return 0;
 }
 
@@ -127,6 +138,11 @@ void viewer_compositor_render(struct viewer_ctx *s)
     struct ngpu_fence *blit_done = NULL;
     ngpu_ctx_end_draw(s->gpu_ctx, viewer_get_frame_time(s), scene_fence,
                       s->current_frame ? &blit_done : NULL);
+
+    /* end_draw presents with swap_interval=1, so it returns shortly after the
+     * vsync. Snapshot the time now: viewer_now_ns() extrapolates next vsync
+     * as last_swap_ns + refresh_period_ns. */
+    s->last_swap_ns = SDL_GetTicksNS();
 
     /* Keep the latest blit_done fence: queue ordering guarantees the new
      * one supersedes the previous one. */

--- a/ngl-tools/viewer_scene.c
+++ b/ngl-tools/viewer_scene.c
@@ -298,13 +298,6 @@ static struct ngl_scene *do_scene_load(struct viewer_ctx *s, const struct scene_
 #define SCENE_DEFAULT_FPS_NUM 60
 #define SCENE_DEFAULT_FPS_DEN 1
 
-static Uint64 frame_interval_ns(int32_t fr_num, int32_t fr_den)
-{
-    if (fr_num <= 0 || fr_den <= 0)
-        return 1000000000ull * SCENE_DEFAULT_FPS_DEN / SCENE_DEFAULT_FPS_NUM;
-    return 1000000000ull * (uint64_t)fr_den / (uint64_t)fr_num;
-}
-
 int scene_thread_func(void *arg)
 {
     struct viewer_ctx *s = arg;
@@ -313,172 +306,99 @@ int scene_thread_func(void *arg)
     uint32_t scene_width = 0;
     uint32_t scene_height = 0;
     struct ngl_scene *active_scene = NULL;
-
-    /*
-     * Pacing state.
-     *
-     *   `next_frame_ns` is the absolute `SDL_GetTicksNS()` deadline at which
-     *   the next `ngl_draw()` should fire.
-     *
-     *   `framerate_num` / `framerate_den` is the rational frame interval of
-     *   the currently loaded scene (or the default fallback when no scene
-     *   declares one). Used both to advance `next_frame_ns` by one interval
-     *   per draw and to snap the wall-clock frame time onto a frame boundary
-     *   before passing it to `ngl_draw()`.
-     *
-     * Together they implement an absolute (rather than relative-sleep)
-     * pacing clock that the rendering loop services in five steps:
-     *
-     *   1. Top of the loop. Before draining any command, compute the timeout
-     *      as `max(0, next_frame_ns - now)` and call `scene_cmd_pop_timed()`
-     *      with that bound. It blocks on the queue for up to that long.
-     *      Posters that enqueue a command wake us early; otherwise we wake
-     *      exactly at the deadline.
-     *   2. Drain any pending commands via `scene_cmd_pop_timed()` without
-     *      blocking. A successful `SCENE_CMD_LOAD` refreshes the rational and
-     *      reseeds `next_frame_ns` to "now" so the first frame of the new scene
-     *      runs immediately. Other commands do not touch the pacing clock.
-     *   3. After draining commands, if `SDL_GetTicksNS()` is still less than
-     *      `next_frame_ns` (we were woken by a command before the deadline),
-     *      `continue` back to step 1 so the next `scene_cmd_pop_timed()`
-     *      sleeps the remainder of the interval instead of redrawing the
-     *      same frame early.
-     *   4. Otherwise call `ngl_draw()`, then unconditionally advance
-     *      `next_frame_ns += interval` — including on `NGL_ERROR_BUSY`,
-     *      which turns a "consumer hasn't released a slot yet" failure into
-     *      a one-interval back-off rather than a tight retry loop.
-     *   5. If after that advance `next_frame_ns` is still behind wall-clock
-     *     (`ngl_draw() tooks more than one interval), resync to "now + interval"
-     *      instead of trying to catch up with a burst of draws — the UI only ever
-     *      consumes the latest frame, so generating a backlog would burn CPU/GPU
-     *      for no benefit.
-     */
     int32_t framerate_num = SCENE_DEFAULT_FPS_NUM;
     int32_t framerate_den = SCENE_DEFAULT_FPS_DEN;
-    Uint64 next_frame_ns = SDL_GetTicksNS();
 
     for (;;) {
         struct scene_cmd cmd;
-        int have_cmd;
-        if (is_active) {
-            const Uint64 now_ns = SDL_GetTicksNS();
-            Sint32 timeout_ms;
-            if (now_ns >= next_frame_ns) {
-                timeout_ms = 0;
-            } else {
-                /*
-                 * Round up so a sub-millisecond remainder doesn't degrade
-                 * into a non-blocking `scene_cmd_pop_timed()`.
-                 */
-                const Uint64 delta_ns = next_frame_ns - now_ns;
-                timeout_ms = (Sint32)((delta_ns + 999999) / 1000000);
-            }
-            have_cmd = scene_cmd_pop_timed(&s->cmd_q, &cmd, timeout_ms);
-        } else {
-            have_cmd = scene_cmd_pop_timed(&s->cmd_q, &cmd, -1);
-        }
+        if (!scene_cmd_pop_timed(&s->cmd_q, &cmd, -1))
+            continue; /* Defensive: timeout=-1 should always deliver something. */
 
-        while (have_cmd) {
-            switch (cmd.type) {
-            case SCENE_CMD_QUIT:
-                scene_cmd_release(&cmd);
-                ngl_scene_unrefp(&active_scene);
-                return 0;
-            case SCENE_CMD_LOAD: {
-                if (cmd.load.request) {
-                    struct ngl_scene *loaded = do_scene_load(s, cmd.load.request);
-                    if (loaded) {
-                        ngl_scene_unrefp(&active_scene);
-                        active_scene = loaded;
-                        is_active = true;
-                        const struct ngl_scene_params *p = ngl_scene_get_params(loaded);
-                        framerate_num = p->framerate[0];
-                        framerate_den = p->framerate[1];
-                        next_frame_ns = SDL_GetTicksNS();
-                    }
+        switch (cmd.type) {
+        case SCENE_CMD_QUIT:
+            scene_cmd_release(&cmd);
+            ngl_scene_unrefp(&active_scene);
+            return 0;
+        case SCENE_CMD_LOAD:
+            if (cmd.load.request) {
+                struct ngl_scene *loaded = do_scene_load(s, cmd.load.request);
+                if (loaded) {
+                    ngl_scene_unrefp(&active_scene);
+                    active_scene = loaded;
+                    is_active = true;
+                    const struct ngl_scene_params *p = ngl_scene_get_params(loaded);
+                    framerate_num = p->framerate[0];
+                    framerate_den = p->framerate[1];
                 }
-                scene_cmd_release(&cmd);
-                break;
             }
-            case SCENE_CMD_RESIZE:
-                scene_width  = cmd.resize.width;
-                scene_height = cmd.resize.height;
-                scene_cmd_release(&cmd);
-                break;
-            case SCENE_CMD_UNLOAD:
-                is_active = false;
-                ngl_scene_unrefp(&active_scene);
-                scene_cmd_release(&cmd);
-                break;
-            case SCENE_CMD_SNAPSHOT: {
-                struct ngl_scene *snap = NULL;
-                if (active_scene) {
-                    const Uint64 t0 = SDL_GetTicksNS();
-                    snap = ngl_scene_duplicate(active_scene);
-                    const Uint64 t1 = SDL_GetTicksNS();
-                    SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
-                                 "ngl_scene_duplicate: %.3f ms",
-                                 (double)(t1 - t0) / 1.0e6);
-                }
-                if (cmd.snapshot.out)
-                    *cmd.snapshot.out = snap;
-                if (cmd.snapshot.done)
-                    SDL_SignalSemaphore(cmd.snapshot.done);
-                cmd.snapshot.out  = NULL;
-                cmd.snapshot.done = NULL;
-                scene_cmd_release(&cmd);
-                break;
+            break;
+        case SCENE_CMD_RESIZE:
+            scene_width  = cmd.resize.width;
+            scene_height = cmd.resize.height;
+            break;
+        case SCENE_CMD_UNLOAD:
+            is_active = false;
+            ngl_scene_unrefp(&active_scene);
+            break;
+        case SCENE_CMD_SNAPSHOT: {
+            struct ngl_scene *snap = NULL;
+            if (active_scene) {
+                const Uint64 t0 = SDL_GetTicksNS();
+                snap = ngl_scene_duplicate(active_scene);
+                const Uint64 t1 = SDL_GetTicksNS();
+                SDL_LogDebug(SDL_LOG_CATEGORY_APPLICATION,
+                             "ngl_scene_duplicate: %.3f ms",
+                             (double)(t1 - t0) / 1.0e6);
             }
-            case SCENE_CMD_CALLBACK:
-                if (cmd.callback.fn)
-                    cmd.callback.fn(s, cmd.callback.arg);
-                scene_cmd_release(&cmd);
+            if (cmd.snapshot.out)
+                *cmd.snapshot.out = snap;
+            if (cmd.snapshot.done)
+                SDL_SignalSemaphore(cmd.snapshot.done);
+            cmd.snapshot.out  = NULL;
+            cmd.snapshot.done = NULL;
+            break;
+        }
+        case SCENE_CMD_CALLBACK:
+            if (cmd.callback.fn)
+                cmd.callback.fn(s, cmd.callback.arg);
+            break;
+        case SCENE_CMD_RENDER: {
+            if (!is_active)
                 break;
+
+            double t = cmd.render.target_time;
+            if (framerate_num > 0 && framerate_den > 0) {
+                const int64_t idx = (int64_t)(t * (double)framerate_num / (double)framerate_den);
+                t = (double)idx * (double)framerate_den / (double)framerate_num;
             }
-            have_cmd = scene_cmd_pop_timed(&s->cmd_q, &cmd, 0);
+
+            if (scene_width >= 2 && scene_height >= 2) {
+                uint32_t rt_width = 0;
+                uint32_t rt_height = 0;
+                struct ngpu_ctx *gpu_ctx = ngl_get_gpu_ctx(s->ngl_ctx);
+                if (gpu_ctx)
+                    ngpu_ctx_get_default_rendertarget_size(gpu_ctx, &rt_width, &rt_height);
+                if (rt_width != scene_width || rt_height != scene_height)
+                    ngl_resize(s->ngl_ctx, scene_width, scene_height);
+            }
+
+            struct ngl_draw_output output = {0};
+            int draw_ret = ngl_draw(s->ngl_ctx, t, &output);
+            if (draw_ret < 0)
+                break;
+
+            SDL_LockMutex(s->frame_lock);
+            struct ngl_frame *previous_frame = s->latest_frame;
+            s->latest_frame = output.frame;
+            SDL_UnlockMutex(s->frame_lock);
+
+            if (previous_frame)
+                ngl_frame_release(previous_frame, NULL);
+            break;
+        }
         }
 
-        if (!is_active)
-            continue;
-
-        if (SDL_GetTicksNS() < next_frame_ns)
-            continue;
-
-        if (scene_width >= 2 && scene_height >= 2) {
-            uint32_t rt_width = 0;
-            uint32_t rt_height = 0;
-            struct ngpu_ctx *gpu_ctx = ngl_get_gpu_ctx(s->ngl_ctx);
-            if (gpu_ctx)
-                ngpu_ctx_get_default_rendertarget_size(gpu_ctx, &rt_width, &rt_height);
-            if (rt_width != scene_width || rt_height != scene_height)
-                ngl_resize(s->ngl_ctx, scene_width, scene_height);
-        }
-
-        double frame_time = viewer_get_frame_time(s);
-        if (framerate_num > 0 && framerate_den > 0) {
-            const int64_t idx = (int64_t)(frame_time * (double)framerate_num / (double)framerate_den);
-            frame_time = (double)idx * (double)framerate_den / (double)framerate_num;
-        }
-
-        struct ngl_draw_output output = {0};
-        int draw_ret = ngl_draw(s->ngl_ctx, frame_time, &output);
-
-        const Uint64 interval_ns = frame_interval_ns(framerate_num, framerate_den);
-        next_frame_ns += interval_ns;
-        const Uint64 now_after_ns = SDL_GetTicksNS();
-        if (next_frame_ns < now_after_ns)
-            next_frame_ns = now_after_ns + interval_ns;
-
-        if (draw_ret < 0)
-            continue;
-
-        SDL_LockMutex(s->frame_lock);
-        struct ngl_frame *previous_frame = s->latest_frame;
-        s->latest_frame = output.frame;
-        SDL_UnlockMutex(s->frame_lock);
-
-        if (previous_frame)
-            ngl_frame_release(previous_frame, NULL);
+        scene_cmd_release(&cmd);
     }
 }
 
@@ -508,11 +428,6 @@ int viewer_scene_init(struct viewer_ctx *s, uint32_t width, uint32_t height)
     s->frame_lock = SDL_CreateMutex();
     if (!s->frame_lock) {
         SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create frame_lock");
-        return -1;
-    }
-    s->frame_time_lock = SDL_CreateMutex();
-    if (!s->frame_time_lock) {
-        SDL_LogError(SDL_LOG_CATEGORY_APPLICATION, "Failed to create frame_time_lock");
         return -1;
     }
 
@@ -560,10 +475,6 @@ void viewer_scene_close(struct viewer_ctx *s)
     if (s->frame_lock) {
         SDL_DestroyMutex(s->frame_lock);
         s->frame_lock = NULL;
-    }
-    if (s->frame_time_lock) {
-        SDL_DestroyMutex(s->frame_time_lock);
-        s->frame_time_lock = NULL;
     }
     ngl_freep(&s->ngl_ctx);
 }

--- a/ngl-tools/viewer_scene.h
+++ b/ngl-tools/viewer_scene.h
@@ -65,6 +65,11 @@ enum scene_cmd_type {
      * rendering context.
      */
     SCENE_CMD_CALLBACK,
+    /*
+     * Render request: the scene thread calls ngl_draw for the given
+     * target_time and publishes the resulting frame into latest_frame.
+     */
+    SCENE_CMD_RENDER,
     SCENE_CMD_QUIT,
 };
 
@@ -87,6 +92,9 @@ struct scene_cmd {
             void (*free_fn)(void *arg); /* Optional. */
             void *arg;
         } callback;
+        struct {
+            double target_time;
+        } render;
     };
 };
 

--- a/ngl-tools/viewer_ui.c
+++ b/ngl-tools/viewer_ui.c
@@ -804,12 +804,12 @@ static int icon_button(struct nk_context *nk, float K, enum icon_kind kind, int 
 void viewer_update_time(struct viewer_ctx *s)
 {
     if (!s->paused) {
-        if (s->clock_off < 0)
-            s->clock_off = (int64_t)SDL_GetTicks();
-        const int64_t now = (int64_t)SDL_GetTicks();
-        double t = (double)(now - s->clock_off) / 1000.0;
+        const int64_t now_ns = (int64_t)viewer_now_ns(s);
+        if (s->clock_off_ns < 0)
+            s->clock_off_ns = now_ns;
+        double t = (double)(now_ns - s->clock_off_ns) / 1.0e9;
         if (s->duration > 0.0 && t >= s->duration) {
-            s->clock_off = now;
+            s->clock_off_ns = now_ns;
             t = 0.0;
         }
         viewer_set_frame_time(s, t);
@@ -1097,7 +1097,7 @@ export_section_done:
         if (icon_button(nk, K, s->paused ? ICON_PLAY : ICON_PAUSE, can_play)) {
             s->paused ^= 1;
             if (!s->paused)
-                s->clock_off = (int64_t)SDL_GetTicks() - (int64_t)(frame_time * 1000.0);
+                s->clock_off_ns = (int64_t)viewer_now_ns(s) - (int64_t)(frame_time * 1.0e9);
         }
         if (icon_button(nk, K, ICON_STEP_FWD, can_step)) {
             s->paused = 1;
@@ -1124,7 +1124,7 @@ export_section_done:
             if (new_seek != seek) {
                 const double t = new_seek * s->duration;
                 viewer_set_frame_time(s, t);
-                s->clock_off = (int64_t)SDL_GetTicks() - (int64_t)(t * 1000.0);
+                s->clock_off_ns = (int64_t)viewer_now_ns(s) - (int64_t)(t * 1.0e9);
             }
         } else {
             nk_spacing(nk, 1);


### PR DESCRIPTION
Replace the scene renderer thread's pacing loop with a UI-driven model. The time the UI hands to the scene renderer is now aligned with the next predicted vsync time.

This comes at the cost of exactly one frame of latency between the UI and the scene.

Fixes the stutter caused by the scene's free-running pacing clock drifting against the display vsync.